### PR TITLE
Display AccountId on refresh page

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -139,7 +139,8 @@ app.all('/refresh', function (req, res) {
         title: 'Rapid7 - Awsaml',
         accessKey: data.Credentials.AccessKeyId,
         secretKey: data.Credentials.SecretAccessKey,
-        sessionToken: data.Credentials.SessionToken
+        sessionToken: data.Credentials.SessionToken,
+        accountId: session.accountId
       })
       credentials.save(data.Credentials, 'awsaml-'+session.accountId, function (err) {
         if (err) {

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -8,6 +8,7 @@ var Refresh = React.createClass({
 <div className="col-centered rounded-6 wrapper">
 <img className="logo" src="https://rapid7.okta.com/bc/image/fileStoreRecord?id=fs011ume6fjY7HcEE0i8" alt="Rapid7" />
 <div className="col-centered rounded-6 content">
+<p>Account ID: {this.props.accountId}</p>
 <p>Access Key: {this.props.accessKey}</p>
 <p>Secret Key: {this.props.secretKey}</p>
 <p>Session Token: {this.props.sessionToken}</p>


### PR DESCRIPTION
This commit adds AccountId to the values displayed on the refresh
page.  This change makes is a little easier which account you are using;
the Okta metadata url is not very descriptive.

