### PR TITLE
Better error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const Application = require('app');
-const BrowserWindow = require('browser-window');
+const electron = require('electron');
+const Application = electron.app;
+const BrowserWindow = electron.BrowserWindow;
+
 const Storage = require('./lib/storage');
 const Server = require('./lib/server');
 const config = require('./config');
@@ -64,11 +66,11 @@ Application.on('ready', () => {
     mainWindow = null;
   });
 
-  mainWindow.loadUrl(Server.get('configureUrl'));
+  mainWindow.loadURL(Server.get('configureUrl'));
   mainWindow.show();
 
   setInterval(() => {
     console.log('Reloading...'); // eslint-disable-line no-console
-    mainWindow.loadUrl(Server.get('entryPointUrl'));
+    mainWindow.loadURL(Server.get('entryPointUrl'));
   }, (config.aws.duration - 10) * 1000); // eslint-disable-line rapid7/static-magic-numbers
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const HTTP_OK = 200;
+
 const path = require('path');
 const https = require('https');
 
@@ -44,6 +46,16 @@ app.use(expressSession({
 app.use(auth.initialize());
 app.use(auth.session());
 
+const Errors = {
+  urlInvalidErr: 'The SAML metadata URL is invalid.',
+  invalidMetadataErr: 'The SAML metadata is invalid.'
+};
+
+const ResponseObj = {
+  title: 'Rapid7 - Awsaml',
+  platform: process.platform
+};
+
 app.post(config.auth.path, auth.authenticate('saml', {
   failureRedirect: app.get('configureUrl'),
   failureFlash: true
@@ -61,24 +73,41 @@ app.post(config.auth.path, auth.authenticate('saml', {
 
 app.get('/configure', (req, res) => {
   let metadataUrl = Storage.get('metadataUrl');
+  const metadataUrlValid = Storage.get('metadataUrlValid');
+  const error = Storage.get('metadataUrlError');
 
   if (!metadataUrl) {
     metadataUrl = '';
   }
 
-  res.render('configure', {
-    title: 'Rapid7 - Awsaml',
-    metadataUrl
-  });
+  res.render('configure', Object.assign(ResponseObj, {
+    metadataUrl,
+    metadataUrlValid,
+    error
+  }));
 });
 
 app.post('/configure', (req, res) => {
   const metadataUrl = req.body.metadataUrl;
+  const metaDataResponseObj = Object.assign(ResponseObj, {metadataUrl});
 
   Storage.set('metadataUrl', metadataUrl);
 
   const xmlReq = https.get(metadataUrl, (xmlRes) => {
     let xml = '';
+
+    if (xmlRes.statusCode !== HTTP_OK) {
+      Storage.set('metadataUrlValid', false);
+      Storage.set('metadataUrlError', Errors.urlInvalidErr);
+
+      res.render('configure', Object.assign(metaDataResponseObj, {
+        metadataUrlValid: false,
+        error: Errors.urlInvalidErr
+      }));
+      return;
+    }
+    Storage.set('metadataUrlValid', true);
+    Storage.set('metadataUrlError', null);
 
     xmlRes.on('data', (chunk) => {
       xml += chunk;
@@ -119,21 +148,17 @@ app.post('/configure', (req, res) => {
         auth.configure(config.auth);
         res.redirect(config.auth.entryPoint);
       } else {
-        res.render('configure', {
-          title: 'Rapid7 - Awsaml',
-          metadataUrl,
-          error: 'The SAML metadata is invalid.'
-        });
+        res.render('configure', Object.assign(metaDataResponseObj, {
+          error: Errors.invalidMetadataErr
+        }));
       }
     });
   });
 
   xmlReq.on('error', (err) => {
-    res.render('configure', {
-      title: 'Rapid7 - Awsaml',
-      metadataUrl,
-      error: err
-    });
+    res.render('configure', Object.assign(metaDataResponseObj, {
+      error: err.message
+    }));
   });
 });
 
@@ -142,7 +167,10 @@ app.all('*', auth.guard);
 app.all('/refresh', (req, res) => {
   const sts = new Aws.STS();
   const session = req.session.passport;
-  const platform = process.platform;
+
+  const refreshResponseObj = Object.assign(ResponseObj, {
+    accountId: session.accountId
+  });
 
   sts.assumeRoleWithSAML({
     PrincipalArn: session.principalArn,
@@ -150,24 +178,26 @@ app.all('/refresh', (req, res) => {
     SAMLAssertion: session.samlResponse,
     DurationSeconds: config.aws.duration
   }, (assumeRoleErr, data) => {
-    if (!assumeRoleErr && data) {
-      res.render('refresh', {
-        title: 'Rapid7 - Awsaml',
-        accessKey: data.Credentials.AccessKeyId,
-        secretKey: data.Credentials.SecretAccessKey,
-        sessionToken: data.Credentials.SessionToken,
-        accountId: session.accountId,
-        platform
-      });
-      credentials.save(data.Credentials, `awsaml-${session.accountId}`, (credSaveErr) => {
-        if (credSaveErr) {
-          res.render('refresh', {
-            error: credSaveErr,
-            platform
-          });
-        }
-      });
+    const credentialResponseObj = Object.assign(refreshResponseObj, {
+      accessKey: data.Credentials.AccessKeyId,
+      secretKey: data.Credentials.SecretAccessKey,
+      sessionToken: data.Credentials.SessionToken
+    });
+
+    if (assumeRoleErr) {
+      res.redirect(config.auth.entryPoint);
+      return;
     }
+
+    res.render('refresh', credentialResponseObj);
+
+    credentials.save(data.Credentials, `awsaml-${session.accountId}`, (credSaveErr) => {
+      if (credSaveErr) {
+        res.render('refresh', Object.assign(credentialResponseObj, {
+          error: credSaveErr
+        }));
+      }
+    });
   });
 });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,7 +36,11 @@ app.use(morgan('dev'));
 app.use(cookieParser(sessionSecret));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
-app.use(expressSession({secret: sessionSecret}));
+app.use(expressSession({
+  secret: sessionSecret,
+  resave: false,
+  saveUninitialized: true
+}));
 app.use(auth.initialize());
 app.use(auth.session());
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "errorhandler": "1.4.2",
     "express": "4.13.3",
     "express-react-views": "0.9.0",
-    "express-session": "1.12.0",
+    "express-session": "1.13.0",
     "ini": "1.3.4",
     "mkdirp": "^0.5.1",
     "morgan": "1.6.1",
@@ -37,8 +37,8 @@
     "xpath.js": "1.0.6"
   },
   "devDependencies": {
-    "electron-packager": "5.1.1",
-    "electron-prebuilt": "0.34.2",
+    "electron-packager": "5.2.1",
+    "electron-prebuilt": "0.36.7",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.0",
     "eslint-config-rapid7": "0.0.15",

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -49,6 +49,6 @@ dd {
   margin-bottom: 10px;
 }
 
-.has-error .form-control {
+.has-error .form-control, :invalid input {
   border: 2px solid red;
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -49,4 +49,6 @@ dd {
   margin-bottom: 10px;
 }
 
-
+.has-error .form-control {
+  border: 2px solid red;
+}

--- a/views/configure.jsx
+++ b/views/configure.jsx
@@ -2,18 +2,31 @@
 
 const React = require('react');
 const DefaultLayout = require('./layouts/default');
+const Error = require('./error');
 
 const propTypes = {
   error: React.PropTypes.string,
   title: React.PropTypes.string.isRequired,
-  metadataUrl: React.PropTypes.string.isRequired
+  metadataUrl: React.PropTypes.string.isRequired,
+  metadataUrlValid: React.PropTypes.bool
 };
 
 class Configure extends React.Component {
+  get errorMessage() {
+    if (this.hasError()) {
+      return (!this.props.error) ? '' : <Error msg={this.props.error} />;
+    }
+    return '';
+  }
+
+  hasError() {
+    return (this.props.error || this.props.metadataUrlValid === false);
+  }
+
   render() {
     let urlGroupClass = 'form-group';
 
-    if (this.props.error) {
+    if (this.hasError()) {
       urlGroupClass += ' has-error';
     }
     return (
@@ -27,6 +40,7 @@ class Configure extends React.Component {
             <form method='post'>
               <fieldset>
                 <legend>Configure</legend>
+                {this.errorMessage}
                 <div className={urlGroupClass}>
                   <label htmlFor='metadataUrl'>SAML Metadata URL</label>
                   <input className='form-control'

--- a/views/error.jsx
+++ b/views/error.jsx
@@ -1,0 +1,23 @@
+'use strict';
+
+const React = require('react');
+
+const propTypes = {
+  msg: React.PropTypes.string.isRequired
+};
+
+class Error extends React.Component {
+  render() {
+    return (
+        <div className='alert alert-danger' role='alert'>
+          <span className='glyphicon glyphicon-exclamation-sign' />
+          &nbsp;{this.props.msg}
+        </div>
+    );
+  }
+}
+
+Error.propTypes = propTypes;
+Error.displayName = 'Error';
+
+module.exports = Error;

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -1,7 +1,9 @@
 const React = require('react');
 const DefaultLayout = require('./layouts/default');
+const Error = require('./error');
 
 const propTypes = {
+  error: React.PropTypes.string,
   title: React.PropTypes.string.isRequired,
   accountId: React.PropTypes.string.isRequired,
   accessKey: React.PropTypes.string.isRequired,
@@ -11,6 +13,12 @@ const propTypes = {
 };
 
 class Refresh extends React.Component {
+  get errorMessage() {
+    if (this.props.error) {
+      return <Error msg={this.props.error} />;
+    }
+    return '';
+  }
 
   get platform() {
     return this.props.platform;
@@ -33,6 +41,7 @@ class Refresh extends React.Component {
             src='https://rapid7.okta.com/bc/image/fileStoreRecord?id=fs011ume6fjY7HcEE0i8'
           />
           <div className='col-centered rounded-6 content'>
+            {this.errorMessage}
             <dl>
               <dt>Account ID:</dt>
               <dd>{this.props.accountId}</dd>


### PR DESCRIPTION
Resolves #5. This adds improved error displays and redirection on certain error conditions. 

In the case of a invalid metadata url or invalid SAML metadata, an error will display on the configure page. If an error occurs with manually refreshing the main page, such as if the user's AWS session has timed out, the user will be redirected to their SAML provider. If the user is still logged in, their AWS credentials will be refreshed and they will be redirected back to the main Awsaml screen.