### PR TITLE
Fix Electron package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node app.js",
     "app": "electron .",
     "prebuild": "rm -rf dist/",
-    "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=all --arch=x64 --version=0.34.1 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
+    "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=all --arch=x64 --version=0.36.7 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
     "postbuild": "export platform=darwin; npm run zip & export platform=linux; npm run zip & export platform=win32; npm run zip",
     "zip": "cd dist/Awsaml-${platform}-x64 && zip -q -FS -r ../awsaml-v${npm_package_version}-${platform}-x64.zip .",
     "lint": "eslint *.js views/*/** lib/*/**"


### PR DESCRIPTION
This fixes #11 by packaging Awsaml with version 0.36.7 of Electron. The application no longer throws an uncaught exception when launched.