### PR TITLE
Fix refresh button broken after AWS session timeout

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -178,16 +178,16 @@ app.all('/refresh', (req, res) => {
     SAMLAssertion: session.samlResponse,
     DurationSeconds: config.aws.duration
   }, (assumeRoleErr, data) => {
+    if (assumeRoleErr) {
+      res.redirect(config.auth.entryPoint);
+      return;
+    }
+
     const credentialResponseObj = Object.assign(refreshResponseObj, {
       accessKey: data.Credentials.AccessKeyId,
       secretKey: data.Credentials.SecretAccessKey,
       sessionToken: data.Credentials.SessionToken
     });
-
-    if (assumeRoleErr) {
-      res.redirect(config.auth.entryPoint);
-      return;
-    }
 
     res.render('refresh', credentialResponseObj);
 


### PR DESCRIPTION
Fixes #12 where clicking the refresh button after the AWS session had timed out would cause the application to crash.