### PR TITLE
Feature prep v1.1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awsaml",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Periodically refreshes AWS access keys",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/rapid7/awsaml.git"
   },
+  "bugs": {
+    "url": "https://github.com/rapid7/awsaml/issues"
+  },
   "main": "app.js",
   "scripts": {
     "debug": "electron . --debug",


### PR DESCRIPTION
This bumps the version number to 1.1.0 for the release. It also adds a link to the issue tracker so the `npm bugs` command works.