### PR TITLE
Feature: Mocha test framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-config-rapid7": "0.0.15",
     "eslint-plugin-rapid7": "^5.0.1",
     "eslint-plugin-react": "^3.16.1",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "should": "^8.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postbuild": "export platform=darwin; npm run zip & export platform=linux; npm run zip & export platform=win32; npm run zip",
     "zip": "cd dist/Awsaml-${platform}-x64 && zip -q -FS -r ../awsaml-v${npm_package_version}-${platform}-x64.zip .",
     "test": "mocha",
-    "lint": "eslint *.js views/*/** lib/*/**"
+    "lint": "eslint *.js views/*/** lib/*/** test/**"
   },
   "dependencies": {
     "aws-sdk": "2.2.11",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-config-airbnb": "^5.0.0",
     "eslint-config-rapid7": "0.0.15",
     "eslint-plugin-rapid7": "^5.0.1",
-    "eslint-plugin-react": "^3.16.1"
+    "eslint-plugin-react": "^3.16.1",
+    "mocha": "^2.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=all --arch=x64 --version=0.36.7 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
     "postbuild": "export platform=darwin; npm run zip & export platform=linux; npm run zip & export platform=win32; npm run zip",
     "zip": "cd dist/Awsaml-${platform}-x64 && zip -q -FS -r ../awsaml-v${npm_package_version}-${platform}-x64.zip .",
+    "test": "mocha",
     "lint": "eslint *.js views/*/** lib/*/**"
   },
   "dependencies": {

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,0 +1,8 @@
+---
+env:
+  mocha: true
+rules:
+  # Arrow functions are discouraged since they can't access the Mocha context.
+  # https://mochajs.org/#arrow-functions
+  func-names: 0
+  prefer-arrow-callback: 0


### PR DESCRIPTION
This fixes #33. The `npm test` command runs [Mocha](https://mochajs.org/) and processes any tests in the "test" folder at the root of the project. An [eslint](http://eslint.org/) configuration is provided for tests so they can use the global Mocha variables and follow [Mocha's recommendation to avoid arrow functions](https://mochajs.org/#arrow-functions). Assertions are provided by the [Should.js](https://shouldjs.github.io/) library.