### PR TITLE
Add logout button to refresh page

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,8 +69,9 @@ Application.on('ready', () => {
   mainWindow.loadURL(Server.get('configureUrl'));
   mainWindow.show();
 
-  setInterval(() => {
+  const tokenRefreshInterval = setInterval(() => {
     console.log('Reloading...'); // eslint-disable-line no-console
     mainWindow.loadURL(Server.get('entryPointUrl'));
   }, (config.aws.duration - 10) * 1000); // eslint-disable-line rapid7/static-magic-numbers
+  Server.set('tokenRefreshInterval', tokenRefreshInterval);
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -163,7 +163,7 @@ app.post('/configure', (req, res) => {
 });
 
 app.get('/logout', (req, res) => {
-  clearInterval();
+  clearInterval(app.get('tokenRefreshInterval'));
   req.session.destroy();
   res.redirect(app.get('configureUrl'));
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -162,6 +162,12 @@ app.post('/configure', (req, res) => {
   });
 });
 
+app.get('/logout', (req, res) => {
+  clearInterval();
+  req.session.destroy();
+  res.redirect(app.get('configureUrl'));
+});
+
 app.all('*', auth.guard);
 
 app.all('/refresh', (req, res) => {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -53,6 +53,6 @@ dd {
   border: 2px solid red;
 }
 
-.btn-default {
+.button-margin {
   margin-left: 10px;
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -52,3 +52,7 @@ dd {
 .has-error .form-control, :invalid input {
   border: 2px solid red;
 }
+
+.btn-default {
+  margin-left: 10px;
+}

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -66,6 +66,7 @@ class Refresh extends React.Component {
               </pre>
             </div>
             <a className='btn btn-default' href='/refresh' role='button'>Refresh</a>
+            <a className='btn btn-default' href='/logout' role='button'>Logout</a>
           </div>
         </div>
       </DefaultLayout>

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -66,7 +66,7 @@ class Refresh extends React.Component {
               </pre>
             </div>
             <a className='btn btn-default button-margin' href='/refresh' role='button'>Refresh</a>
-            <a className='btn btn-default button-margin' href='/logout' role='button'>Logout</a>
+            <a className='btn btn-danger button-margin' href='/logout' role='button'>Logout</a>
           </div>
         </div>
       </DefaultLayout>

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -65,8 +65,8 @@ class Refresh extends React.Component {
                 </code>
               </pre>
             </div>
-            <a className='btn btn-default' href='/refresh' role='button'>Refresh</a>
-            <a className='btn btn-default' href='/logout' role='button'>Logout</a>
+            <a className='btn btn-default button-margin' href='/refresh' role='button'>Refresh</a>
+            <a className='btn btn-default button-margin' href='/logout' role='button'>Logout</a>
           </div>
         </div>
       </DefaultLayout>


### PR DESCRIPTION
This change adds a logout button the `refresh` page and a logout endpoint that does the following:
* Clears the refresh interval
* Clears the session data
* Redirects to the `configureUrl`

I'm not sure how to go about writing tests for this... 

Fixes #48 