### PR TITLE
Fix: Upgrade Electron packaging

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,8 +45,8 @@ Application.on('ready', () => {
     width: lastWindowState.width,
     height: lastWindowState.height,
     show: false,
-    'web-preferences': {
-      'node-integration': false
+    'webPreferences': {
+      'nodeIntegration': false
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "xpath.js": "1.0.6"
   },
   "devDependencies": {
-    "electron-packager": "7.0.0",
+    "electron-packager": "7.0.1",
     "electron-prebuilt": "0.37.6",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node app.js",
     "app": "electron .",
     "prebuild": "rm -rf dist/",
-    "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=all --arch=x64 --version=0.36.7 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
+    "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=all --arch=x64 --version=0.37.6 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
     "postbuild": "export platform=darwin; npm run zip & export platform=linux; npm run zip & export platform=win32; npm run zip",
     "zip": "cd dist/Awsaml-${platform}-x64 && zip -q -FS -r ../awsaml-v${npm_package_version}-${platform}-x64.zip .",
     "test": "mocha",
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "electron-packager": "7.0.0",
-    "electron-prebuilt": "0.36.7",
+    "electron-prebuilt": "0.37.6",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.0",
     "eslint-config-rapid7": "0.0.15",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node app.js",
     "app": "electron .",
     "prebuild": "rm -rf dist/",
-    "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=darwin,linux,win32 --arch=x64 --version=0.37.6 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
+    "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=darwin,linux,win32 --arch=x64 --version=0.37.8 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
     "postbuild": "export platform=darwin; npm run zip & export platform=linux; npm run zip & export platform=win32; npm run zip",
     "zip": "cd dist/Awsaml-${platform}-x64 && zip -q -FS -r ../awsaml-v${npm_package_version}-${platform}-x64.zip .",
     "test": "mocha",
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "electron-packager": "7.0.1",
-    "electron-prebuilt": "0.37.6",
+    "electron-prebuilt": "0.37.8",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.0",
     "eslint-config-rapid7": "0.0.15",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "xpath.js": "1.0.6"
   },
   "devDependencies": {
-    "electron-packager": "5.2.1",
+    "electron-packager": "7.0.0",
     "electron-prebuilt": "0.36.7",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node app.js",
     "app": "electron .",
     "prebuild": "rm -rf dist/",
-    "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=all --arch=x64 --version=0.37.6 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
+    "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=darwin,linux,win32 --arch=x64 --version=0.37.6 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
     "postbuild": "export platform=darwin; npm run zip & export platform=linux; npm run zip & export platform=win32; npm run zip",
     "zip": "cd dist/Awsaml-${platform}-x64 && zip -q -FS -r ../awsaml-v${npm_package_version}-${platform}-x64.zip .",
     "test": "mocha",


### PR DESCRIPTION
This fixes #52. [electron-packager](https://www.npmjs.com/package/electron-packager) has been upgraded to version 7.0.1 and [electron-prebuilt](https://www.npmjs.com/package/electron-prebuilt) has been upgraded to version 0.37.8.