### PR TITLE
Remove electron dependency from local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.log
 .DS_Store
+test/data/test.json

--- a/app.js
+++ b/app.js
@@ -3,10 +3,13 @@
 const electron = require('electron');
 const Application = electron.app;
 const BrowserWindow = electron.BrowserWindow;
-
-const Storage = require('./lib/storage');
+const app = require('app');
+const path = require('path');
 const Server = require('./lib/server');
 const config = require('./config');
+const storagePath = path.join(app.getPath('userData'), 'data.json');
+
+global.Storage = require('./lib/storage')(storagePath);
 
 const WindowWidth = 800;
 const WindowHeight = 800;
@@ -45,8 +48,8 @@ Application.on('ready', () => {
     width: lastWindowState.width,
     height: lastWindowState.height,
     show: false,
-    'webPreferences': {
-      'nodeIntegration': false
+    webPreferences: {
+      nodeIntegration: false
     }
   });
 
@@ -73,5 +76,6 @@ Application.on('ready', () => {
     console.log('Reloading...'); // eslint-disable-line no-console
     mainWindow.loadURL(Server.get('entryPointUrl'));
   }, (config.aws.duration - 10) * 1000); // eslint-disable-line rapid7/static-magic-numbers
+
   Server.set('tokenRefreshInterval', tokenRefreshInterval);
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,7 +19,6 @@ const xpath = require('xpath.js');
 const config = require('../config');
 const Auth = require('../lib/auth');
 const AwsCredentials = require('../lib/aws-credentials');
-const Storage = require('../lib/storage');
 
 const sessionSecret = '491F9BAD-DFFF-46E2-A0F9-56397B538060';
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,15 +1,20 @@
 'use strict';
 
-const app = require('app');
 const fs = require('fs');
-const path = require('path');
 
 class Storage {
-  constructor() {
+  /**
+   * Constructor
+   * @param {string} file
+   */
+  constructor(file) {
     this.data = null;
-    this.file = path.join(app.getPath('userData'), 'data.json');
+    this.file = file;
   }
 
+  /**
+   * Load the storage file
+   */
   load() {
     if (this.data !== null) {
       return;
@@ -21,18 +26,31 @@ class Storage {
     this.data = JSON.parse(fs.readFileSync(this.file, 'utf8'));
   }
 
+  /**
+   * Save the storage file
+   */
   save() {
     if (this.data !== null) {
       fs.writeFileSync(this.file, JSON.stringify(this.data), 'utf8');
     }
   }
 
+  /**
+   * Set the value specified by key
+   * @param {string} key
+   * @param {*} value
+   */
   set(key, value) {
     this.load();
     this.data[key] = value;
     this.save();
   }
 
+  /**
+   * Get the value by key
+   * @param {string} key
+   * @returns {*}
+   */
   get(key) {
     let value = null;
 
@@ -44,4 +62,4 @@ class Storage {
   }
 }
 
-module.exports = new Storage();
+module.exports = (path) => new Storage(path);

--- a/local.js
+++ b/local.js
@@ -1,0 +1,13 @@
+'use strict';
+const path = require('path');
+const Server = require('./lib/server');
+const storagePath = path.join(__dirname, 'test', 'data', 'test.json');
+
+global.Storage = require('./lib/storage')(storagePath);
+
+const host = Server.get('host');
+const port = Server.get('port');
+
+Server.listen(port, host, () => {
+  console.log('Server listening on http://%s:%s', host, port); // eslint-disable-line no-console
+});

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "main": "app.js",
   "scripts": {
-    "debug": "electron . --debug",
-    "start": "node local.js",
-    "app": "electron .",
+    "electron-debug": "electron . --debug",
+    "electron-start": "electron .",
+    "local-start": "node local.js",
     "prebuild": "rm -rf dist/",
     "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=darwin,linux,win32 --arch=x64 --version=0.37.8 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
     "postbuild": "export platform=darwin; npm run zip & export platform=linux; npm run zip & export platform=win32; npm run zip",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "app.js",
   "scripts": {
     "debug": "electron . --debug",
-    "start": "node app.js",
+    "start": "node local.js",
     "app": "electron .",
     "prebuild": "rm -rf dist/",
     "build": "electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=dist --out=dist --platform=darwin,linux,win32 --arch=x64 --version=0.37.8 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",


### PR DESCRIPTION
This PR includes the following features:

1. A refactored `Storage` class that accepts a file path.
1. A wrapper file that allows users to run the webserver backend without any Electron dependencies.
1. Updated npm task names for clarity and added a new task to run the local webserver.

This is the first part of #23 and will allow us to test a webpacked frontend against a backend without Electron dependencies.