### PR TITLE
Feature prep v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Change Log
+
+## [Unreleased]
+
+## [1.2.0] - 2016-05-13
+### Added
+- Ability to run server backend locally without Electron by @dgreene-r7.
+- Logout button and server endpoint by @devkmsg.
+- Mocha test framework by @onefrankguy.
+
+### Changed
+- Electron version to 0.37.8 by @onefrankguy.
+
+### Fixed
+- Documentation to use the correct audience restriction URL by @erran.
+
+## [1.1.0] - 2016-02-22
+### Added
+- Display of error messages for invalid metadata URLs by @dgreene-r7.
+- Display of setup commands to make configuring CLI tools easier by @dgreene-r7.
+- Display of AWS account ID to make using multiple accounts easier by @athompson-r7.
+
+### Changed
+- Electron version to 0.36.7 by @onefrankguy.
+- Code formatting to match the Rapid7 Style Guide by @dgreene-r7.
+
+### Fixed
+- Issue where refresh button didn't work after session timeout by @dgreene-r7.
+
+## [1.0.0] - 2016-01-19
+### Added
+- Initial release by @onefrankguy.
+
+[Unreleased]: https://github.com/rapid7/awsaml/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/rapid7/awsaml/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/rapid7/awsaml/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/rapid7/awsaml/tree/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awsaml",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Periodically refreshes AWS access keys",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This bumps the version number to 1.2.0 for the release.