### PR TITLE
Refactor routes

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  title: 'Rapid7 - Awsaml',
+  platform: process.platform
+};

--- a/lib/routes/auth.js
+++ b/lib/routes/auth.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+
+module.exports = (app, auth) => {
+  router.post('/', auth.authenticate('saml', {
+    failureRedirect: app.get('configureUrl'),
+    failureFlash: true
+  }), (req, res) => {
+    const arns = req.user['https://aws.amazon.com/SAML/Attributes/Role'].split(',');
+
+    /* eslint-disable no-param-reassign */
+    req.session.passport.samlResponse = req.body.SAMLResponse;
+    req.session.passport.roleArn = arns[0];
+    req.session.passport.principalArn = arns[1];
+    req.session.passport.accountId = arns[0].split(':')[4]; // eslint-disable-line rapid7/static-magic-numbers
+    /* eslint-enable no-param-reassign */
+    res.redirect('/refresh');
+  });
+
+  return router;
+};

--- a/lib/routes/configure.js
+++ b/lib/routes/configure.js
@@ -18,18 +18,10 @@ const ResponseObj = require('./../response');
 
 module.exports = (app, auth) => {
   router.get('/', (req, res) => {
-    let metadataUrl = Storage.get('metadataUrl');
-    const metadataUrlValid = Storage.get('metadataUrlValid');
-    const error = Storage.get('metadataUrlError');
-
-    if (!metadataUrl) {
-      metadataUrl = '';
-    }
-
     res.render('configure', Object.assign(ResponseObj, {
-      metadataUrl,
-      metadataUrlValid,
-      error
+      metadataUrl: Storage.get('metadataUrl') || '',
+      metadataUrlValid: Storage.get('metadataUrlValid'),
+      error: Storage.get('metadataUrlError')
     }));
   });
 

--- a/lib/routes/configure.js
+++ b/lib/routes/configure.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const https = require('https');
+const express = require('express');
+const router = express.Router();
+
+const xmldom = require('xmldom');
+const xpath = require('xpath.js');
+const config = require('../../config');
+
+const HTTP_OK = 200;
+
+const Errors = {
+  urlInvalidErr: 'The SAML metadata URL is invalid.',
+  invalidMetadataErr: 'The SAML metadata is invalid.'
+};
+const ResponseObj = require('./../response');
+
+module.exports = (app, auth) => {
+  router.get('/', (req, res) => {
+    let metadataUrl = Storage.get('metadataUrl');
+    const metadataUrlValid = Storage.get('metadataUrlValid');
+    const error = Storage.get('metadataUrlError');
+
+    if (!metadataUrl) {
+      metadataUrl = '';
+    }
+
+    res.render('configure', Object.assign(ResponseObj, {
+      metadataUrl,
+      metadataUrlValid,
+      error
+    }));
+  });
+
+  router.post('/', (req, res) => {
+    const metadataUrl = req.body.metadataUrl;
+    const metaDataResponseObj = Object.assign(ResponseObj, {metadataUrl});
+
+    Storage.set('metadataUrl', metadataUrl);
+
+    const xmlReq = https.get(metadataUrl, (xmlRes) => {
+      let xml = '';
+
+      if (xmlRes.statusCode !== HTTP_OK) {
+        Storage.set('metadataUrlValid', false);
+        Storage.set('metadataUrlError', Errors.urlInvalidErr);
+
+        res.render('configure', Object.assign(metaDataResponseObj, {
+          metadataUrlValid: false,
+          error: Errors.urlInvalidErr
+        }));
+        return;
+      }
+      Storage.set('metadataUrlValid', true);
+      Storage.set('metadataUrlError', null);
+
+      xmlRes.on('data', (chunk) => {
+        xml += chunk;
+      });
+
+      xmlRes.on('end', () => {
+        const xmlDoc = new xmldom.DOMParser().parseFromString(xml);
+        const safeXpath = (doc, p) => {
+          try {
+            return xpath(doc, p);
+          } catch (_) {
+            return null;
+          }
+        };
+
+        let cert = safeXpath(xmlDoc, '//*[local-name(.)=\'X509Certificate\']/text()'),
+            issuer = safeXpath(xmlDoc, '//*[local-name(.)=\'EntityDescriptor\']/@entityID'),
+            entryPoint = safeXpath(xmlDoc, '//*[local-name(.)=\'SingleSignOnService\' and' +
+                ' @Binding=\'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\']/@Location');
+
+        if (cert) {
+          cert = cert.length ? cert[0].data.replace(/\s+/g, '') : null;
+        }
+        config.auth.cert = cert;
+
+        if (issuer) {
+          issuer = issuer.length ? issuer[0].value : null;
+        }
+        config.auth.issuer = issuer;
+
+        if (entryPoint) {
+          entryPoint = entryPoint.length ? entryPoint[0].value : null;
+        }
+        config.auth.entryPoint = entryPoint;
+
+        if (cert && issuer && entryPoint) {
+          app.set('entryPointUrl', config.auth.entryPoint);
+          auth.configure(config.auth);
+          res.redirect(config.auth.entryPoint);
+        } else {
+          res.render('configure', Object.assign(metaDataResponseObj, {
+            error: Errors.invalidMetadataErr
+          }));
+        }
+      });
+    });
+
+    xmlReq.on('error', (err) => {
+      res.render('configure', Object.assign(metaDataResponseObj, {
+        error: err.message
+      }));
+    });
+  });
+
+  return router;
+};

--- a/lib/routes/logout.js
+++ b/lib/routes/logout.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+
+module.exports = (app) => {
+  router.get('/', (req, res) => {
+    clearInterval(app.get('tokenRefreshInterval'));
+    req.session.destroy();
+    res.redirect(app.get('configureUrl'));
+  });
+
+  return router;
+};

--- a/lib/routes/refresh.js
+++ b/lib/routes/refresh.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+
+const config = require('../../config');
+
+const Aws = require('aws-sdk');
+const AwsCredentials = require('../../lib/aws-credentials');
+const credentials = new AwsCredentials(config.aws);
+
+const ResponseObj = require('./../response');
+
+router.all('/', (req, res) => {
+  const sts = new Aws.STS();
+  const session = req.session.passport;
+
+  const refreshResponseObj = Object.assign(ResponseObj, {
+    accountId: session.accountId
+  });
+
+  sts.assumeRoleWithSAML({
+    PrincipalArn: session.principalArn,
+    RoleArn: session.roleArn,
+    SAMLAssertion: session.samlResponse,
+    DurationSeconds: config.aws.duration
+  }, (assumeRoleErr, data) => {
+    if (assumeRoleErr) {
+      res.redirect(config.auth.entryPoint);
+      return;
+    }
+
+    const credentialResponseObj = Object.assign(refreshResponseObj, {
+      accessKey: data.Credentials.AccessKeyId,
+      secretKey: data.Credentials.SecretAccessKey,
+      sessionToken: data.Credentials.SessionToken
+    });
+
+    res.render('refresh', credentialResponseObj);
+
+    credentials.save(data.Credentials, `awsaml-${session.accountId}`, (credSaveErr) => {
+      if (credSaveErr) {
+        res.render('refresh', Object.assign(credentialResponseObj, {
+          error: credSaveErr
+        }));
+      }
+    });
+  });
+});
+
+module.exports = router;

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const path = require('path');
+const express = require('express');
+const morgan = require('morgan');
+const cookieParser = require('cookie-parser');
+const bodyParser = require('body-parser');
+const expressSession = require('express-session');
+const app = express();
+
+module.exports = (auth, config, secret) => {
+  app.set('host', config.server.host);
+  app.set('port', config.server.port);
+  app.set('configureUrl', `http://${config.server.host}:${config.server.port}/configure`);
+  app.set('views', path.join(__dirname, '..', 'views'));
+  app.set('view engine', 'jsx');
+  app.engine('jsx', require('express-react-views').createEngine());
+  app.use(express.static(path.join(__dirname, '..', 'public')));
+  app.use(morgan('dev'));
+  app.use(cookieParser(secret));
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({extended: true}));
+  app.use(expressSession({
+    secret,
+    resave: false,
+    saveUninitialized: true
+  }));
+  app.use(auth.initialize());
+  app.use(auth.session());
+
+  return app;
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,209 +1,21 @@
 'use strict';
 
-const HTTP_OK = 200;
-
-const path = require('path');
-const https = require('https');
-
-const express = require('express');
-const morgan = require('morgan');
-const cookieParser = require('cookie-parser');
-const bodyParser = require('body-parser');
-const expressSession = require('express-session');
 const errorHandler = require('errorhandler');
-
-const Aws = require('aws-sdk');
-const xmldom = require('xmldom');
-const xpath = require('xpath.js');
-
 const config = require('../config');
 const Auth = require('../lib/auth');
-const AwsCredentials = require('../lib/aws-credentials');
 
 const sessionSecret = '491F9BAD-DFFF-46E2-A0F9-56397B538060';
 
 const auth = new Auth(config.auth);
-const credentials = new AwsCredentials(config.aws);
-const app = express();
+const app = require('./server-config')(auth, config, sessionSecret);
 
-app.set('host', config.server.host);
-app.set('port', config.server.port);
-app.set('configureUrl', `http://${config.server.host}:${config.server.port}/configure`);
-app.set('views', path.join(__dirname, '..', 'views'));
-app.set('view engine', 'jsx');
-app.engine('jsx', require('express-react-views').createEngine());
-app.use(express.static(path.join(__dirname, '..', 'public')));
-app.use(morgan('dev'));
-app.use(cookieParser(sessionSecret));
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended: true}));
-app.use(expressSession({
-  secret: sessionSecret,
-  resave: false,
-  saveUninitialized: true
-}));
-app.use(auth.initialize());
-app.use(auth.session());
-
-const Errors = {
-  urlInvalidErr: 'The SAML metadata URL is invalid.',
-  invalidMetadataErr: 'The SAML metadata is invalid.'
-};
-
-const ResponseObj = {
-  title: 'Rapid7 - Awsaml',
-  platform: process.platform
-};
-
-app.post(config.auth.path, auth.authenticate('saml', {
-  failureRedirect: app.get('configureUrl'),
-  failureFlash: true
-}), (req, res) => {
-  const arns = req.user['https://aws.amazon.com/SAML/Attributes/Role'].split(',');
-
-  /* eslint-disable no-param-reassign */
-  req.session.passport.samlResponse = req.body.SAMLResponse;
-  req.session.passport.roleArn = arns[0];
-  req.session.passport.principalArn = arns[1];
-  req.session.passport.accountId = arns[0].split(':')[4]; // eslint-disable-line rapid7/static-magic-numbers
-  /* eslint-enable no-param-reassign */
-  res.redirect('/refresh');
-});
-
-app.get('/configure', (req, res) => {
-  let metadataUrl = Storage.get('metadataUrl');
-  const metadataUrlValid = Storage.get('metadataUrlValid');
-  const error = Storage.get('metadataUrlError');
-
-  if (!metadataUrl) {
-    metadataUrl = '';
-  }
-
-  res.render('configure', Object.assign(ResponseObj, {
-    metadataUrl,
-    metadataUrlValid,
-    error
-  }));
-});
-
-app.post('/configure', (req, res) => {
-  const metadataUrl = req.body.metadataUrl;
-  const metaDataResponseObj = Object.assign(ResponseObj, {metadataUrl});
-
-  Storage.set('metadataUrl', metadataUrl);
-
-  const xmlReq = https.get(metadataUrl, (xmlRes) => {
-    let xml = '';
-
-    if (xmlRes.statusCode !== HTTP_OK) {
-      Storage.set('metadataUrlValid', false);
-      Storage.set('metadataUrlError', Errors.urlInvalidErr);
-
-      res.render('configure', Object.assign(metaDataResponseObj, {
-        metadataUrlValid: false,
-        error: Errors.urlInvalidErr
-      }));
-      return;
-    }
-    Storage.set('metadataUrlValid', true);
-    Storage.set('metadataUrlError', null);
-
-    xmlRes.on('data', (chunk) => {
-      xml += chunk;
-    });
-
-    xmlRes.on('end', () => {
-      const xmlDoc = new xmldom.DOMParser().parseFromString(xml);
-      const safeXpath = (doc, p) => {
-        try {
-          return xpath(doc, p);
-        } catch (_) {
-          return null;
-        }
-      };
-
-      let cert = safeXpath(xmlDoc, '//*[local-name(.)=\'X509Certificate\']/text()'),
-          issuer = safeXpath(xmlDoc, '//*[local-name(.)=\'EntityDescriptor\']/@entityID'),
-          entryPoint = safeXpath(xmlDoc, '//*[local-name(.)=\'SingleSignOnService\' and' +
-              ' @Binding=\'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\']/@Location');
-
-      if (cert) {
-        cert = cert.length ? cert[0].data.replace(/\s+/g, '') : null;
-      }
-      config.auth.cert = cert;
-
-      if (issuer) {
-        issuer = issuer.length ? issuer[0].value : null;
-      }
-      config.auth.issuer = issuer;
-
-      if (entryPoint) {
-        entryPoint = entryPoint.length ? entryPoint[0].value : null;
-      }
-      config.auth.entryPoint = entryPoint;
-
-      if (cert && issuer && entryPoint) {
-        app.set('entryPointUrl', config.auth.entryPoint);
-        auth.configure(config.auth);
-        res.redirect(config.auth.entryPoint);
-      } else {
-        res.render('configure', Object.assign(metaDataResponseObj, {
-          error: Errors.invalidMetadataErr
-        }));
-      }
-    });
-  });
-
-  xmlReq.on('error', (err) => {
-    res.render('configure', Object.assign(metaDataResponseObj, {
-      error: err.message
-    }));
-  });
-});
-
-app.get('/logout', (req, res) => {
-  clearInterval(app.get('tokenRefreshInterval'));
-  req.session.destroy();
-  res.redirect(app.get('configureUrl'));
-});
-
-app.all('*', auth.guard);
-
-app.all('/refresh', (req, res) => {
-  const sts = new Aws.STS();
-  const session = req.session.passport;
-
-  const refreshResponseObj = Object.assign(ResponseObj, {
-    accountId: session.accountId
-  });
-
-  sts.assumeRoleWithSAML({
-    PrincipalArn: session.principalArn,
-    RoleArn: session.roleArn,
-    SAMLAssertion: session.samlResponse,
-    DurationSeconds: config.aws.duration
-  }, (assumeRoleErr, data) => {
-    if (assumeRoleErr) {
-      res.redirect(config.auth.entryPoint);
-      return;
-    }
-
-    const credentialResponseObj = Object.assign(refreshResponseObj, {
-      accessKey: data.Credentials.AccessKeyId,
-      secretKey: data.Credentials.SecretAccessKey,
-      sessionToken: data.Credentials.SessionToken
-    });
-
-    res.render('refresh', credentialResponseObj);
-
-    credentials.save(data.Credentials, `awsaml-${session.accountId}`, (credSaveErr) => {
-      if (credSaveErr) {
-        res.render('refresh', Object.assign(credentialResponseObj, {
-          error: credSaveErr
-        }));
-      }
-    });
-  });
+[
+  {name: config.auth.path, route: require('./routes/auth')(app, auth)},
+  {name: '/configure', route: require('./routes/configure')(app, auth)},
+  {name: '/logout', route: require('./routes/logout')(app)},
+  {name: '/refresh', route: require('./routes/refresh')}
+].forEach((el) => {
+  app.use(el.name, el.route);
 });
 
 app.use(errorHandler());

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,7 @@ const app = require('./server-config')(auth, config, sessionSecret);
 ].forEach((el) => {
   app.use(el.name, el.route);
 });
+app.all('*', auth.guard);
 
 app.use(errorHandler());
 


### PR DESCRIPTION
This PR is the next step in addressing #23. It refactors routes out of the monolithic `lib/server.js` into their own routes. It also moves the responsibility for server configuration into its own module.

This gives us a foundation for further refactoring these routes into RESTful ones that serve JSON rather than a `react-view`.