### PR TITLE
Fix: Renew fails after logout

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,7 +72,7 @@ Application.on('ready', () => {
   mainWindow.loadURL(Server.get('configureUrl'));
   mainWindow.show();
 
-  const tokenRefreshInterval = setInterval(() => {
+  setInterval(() => {
     const entryPointUrl = Server.get('entryPointUrl');
 
     if (entryPointUrl) {
@@ -80,6 +80,4 @@ Application.on('ready', () => {
       mainWindow.loadURL(entryPointUrl);
     }
   }, (config.aws.duration - 10) * 1000); // eslint-disable-line rapid7/static-magic-numbers
-
-  Server.set('tokenRefreshInterval', tokenRefreshInterval);
 });

--- a/app.js
+++ b/app.js
@@ -73,8 +73,12 @@ Application.on('ready', () => {
   mainWindow.show();
 
   const tokenRefreshInterval = setInterval(() => {
-    console.log('Reloading...'); // eslint-disable-line no-console
-    mainWindow.loadURL(Server.get('entryPointUrl'));
+    const entryPointUrl = Server.get('entryPointUrl');
+
+    if (entryPointUrl) {
+      console.log('Reloading...'); // eslint-disable-line no-console
+      mainWindow.loadURL(entryPointUrl);
+    }
   }, (config.aws.duration - 10) * 1000); // eslint-disable-line rapid7/static-magic-numbers
 
   Server.set('tokenRefreshInterval', tokenRefreshInterval);

--- a/lib/routes/logout.js
+++ b/lib/routes/logout.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 module.exports = (app) => {
   router.get('/', (req, res) => {
-    clearInterval(app.get('tokenRefreshInterval'));
+    app.set('entryPointUrl', null);
     req.session.destroy();
     res.redirect(app.get('configureUrl'));
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,7 @@ const app = require('./server-config')(auth, config, sessionSecret);
 ].forEach((el) => {
   app.use(el.name, el.route);
 });
+
 app.all('*', auth.guard);
 
 app.use(errorHandler());

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,7 +17,6 @@ const app = require('./server-config')(auth, config, sessionSecret);
 ].forEach((el) => {
   app.use(el.name, el.route);
 });
-
 app.all('*', auth.guard);
 
 app.use(errorHandler());


### PR DESCRIPTION
This fixes #60.

The automatic token renewal process now runs, even if you log out and log back in.