### PR TITLE
Feature: AwsCredentials tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+test/.aws/
 *.log
 .DS_Store
 test/data/test.json

--- a/lib/aws-credentials.js
+++ b/lib/aws-credentials.js
@@ -12,6 +12,11 @@ class AwsCredentials {
 
   saveAsIniFile(credentials, profile, done) {
     const home = AwsCredentials.resolveHomePath();
+
+    if (!home) {
+      return done(new Error('Cannot save AWS credentials, HOME path not set'));
+    }
+
     const configFile = path.join(home, '.aws', 'credentials');
 
     if (!credentials) {
@@ -20,10 +25,6 @@ class AwsCredentials {
 
     if (!profile) {
       return done(new Error('Cannot save AWS credentials, profile not set'));
-    }
-
-    if (!home) {
-      return done(new Error('Cannot save AWS credentials, HOME path not set'));
     }
 
     // mkdirp is a no-op if the directory already exists

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -6,3 +6,5 @@ rules:
   # https://mochajs.org/#arrow-functions
   func-names: 0
   prefer-arrow-callback: 0
+  # Nested callbacks happen when writing BDD style tests. It's okay.
+  max-nested-callbacks: 0

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -22,8 +22,7 @@ describe('AwsCredentials#saveAsIniFile', function () {
   it('returns an error when credentials are null', function (done) {
     const aws = new AwsCredentials();
 
-    aws.saveAsIniFile(null, 'profile', (error, data) => {
-      should(data).be.undefined();
+    aws.saveAsIniFile(null, 'profile', (error) => {
       error.toString().should.not.eql('');
       done();
     });
@@ -32,8 +31,7 @@ describe('AwsCredentials#saveAsIniFile', function () {
   it('returns an error when profile is null', function (done) {
     const aws = new AwsCredentials();
 
-    aws.saveAsIniFile({}, null, (error, data) => {
-      should(data).be.undefined();
+    aws.saveAsIniFile({}, null, (error) => {
       error.toString().should.not.eql('');
       done();
     });
@@ -47,8 +45,7 @@ describe('AwsCredentials#saveAsIniFile', function () {
     delete process.env.HOMEPATH;
     delete process.env.HOMEDRIVE;
 
-    aws.saveAsIniFile({}, 'profile', (error, data) => {
-      should(data).be.undefined();
+    aws.saveAsIniFile({}, 'profile', (error) => {
       error.toString().should.not.eql('');
       done();
     });
@@ -59,8 +56,7 @@ describe('AwsCredentials#saveAsIniFile', function () {
 
     process.env.HOME = '';
 
-    aws.saveAsIniFile({}, 'profile', (error, data) => {
-      should(data).be.undefined();
+    aws.saveAsIniFile({}, 'profile', (error) => {
       error.toString().should.not.eql('');
       done();
     });

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -140,6 +140,24 @@ describe('AwsCredentials#saveAsIniFile', function () {
       done();
     });
   });
+
+  it('saves the session token as a security token in the credentials file', function (done) {
+    const aws = new AwsCredentials();
+    const credentials = {
+      SessionToken: 'SessionToken'
+    };
+
+    process.env.HOME = __dirname;
+
+    aws.saveAsIniFile(credentials, 'profile', (error) => {
+      const data = FS.readFileSync(awsCredentials, 'utf-8');
+      const config = ini.parse(data);
+
+      should(error).be.null();
+      should(config.profile.aws_security_token).eql(credentials.SessionToken);
+      done();
+    });
+  });
 });
 
 describe('AwsCredentials#resolveHomePath', function () {

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -73,6 +73,18 @@ describe('AwsCredentials#saveAsIniFile', function () {
       done();
     });
   });
+
+  it('creates a $HOME/.aws folder with 0700 permissions', function (done) {
+    const aws = new AwsCredentials();
+
+    process.env.HOME = __dirname;
+
+    aws.saveAsIniFile({}, 'profile', (error) => {
+      should(FS.statSync(awsFolder).mode & 0x0700).eql(256);
+      should(error).be.null();
+      done();
+    });
+  });
 });
 
 describe('AwsCredentials#resolveHomePath', function () {

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -38,6 +38,18 @@ describe('AwsCredentials#saveAsIniFile', function () {
       done();
     });
   });
+
+  it('returns an error when $HOME path is empty', function (done) {
+    const aws = new AwsCredentials();
+
+    process.env.HOME = '';
+
+    aws.saveAsIniFile({}, 'profile', (error, data) => {
+      should(data).be.undefined();
+      error.toString().should.not.eql('');
+      done();
+    });
+  });
 });
 
 describe('AwsCredentials#resolveHomePath', function () {

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -104,6 +104,24 @@ describe('AwsCredentials#saveAsIniFile', function () {
       done();
     });
   });
+
+  it('saves the secret key in the credentials file', function (done) {
+    const aws = new AwsCredentials();
+    const credentials = {
+      SecretAccessKey: 'SecretAccessKey'
+    };
+
+    process.env.HOME = __dirname;
+
+    aws.saveAsIniFile(credentials, 'profile', (error) => {
+      const data = FS.readFileSync(awsCredentials, 'utf-8');
+      const config = ini.parse(data);
+
+      should(error).be.null();
+      should(config.profile.aws_secret_access_key).eql(credentials.SecretAccessKey);
+      done();
+    });
+  });
 });
 
 describe('AwsCredentials#resolveHomePath', function () {

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -81,7 +81,7 @@ describe('AwsCredentials#saveAsIniFile', function () {
     process.env.HOME = __dirname;
 
     aws.saveAsIniFile({}, 'profile', (error) => {
-      should(FS.statSync(awsFolder).mode & 0x0700).eql(256);
+      should(FS.statSync(awsFolder).mode & 0x0700).eql(256); // eslint-disable-line no-bitwise
       should(error).be.null();
       done();
     });

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -3,6 +3,43 @@
 const AwsCredentials = require('../lib/aws-credentials');
 const should = require('should');
 
+describe('AwsCredentials#saveAsIniFile', function () {
+  it("returns an error if credentials aren't given", function (done) {
+    const aws = new AwsCredentials();
+
+    aws.saveAsIniFile(null, 'profile', (error, data) => {
+      should(data).be.undefined();
+      error.toString().should.not.eql('');
+      done();
+    });
+  });
+
+  it("returns an error if a profile isn't given", function (done) {
+    const aws = new AwsCredentials();
+
+    aws.saveAsIniFile({}, null, (error, data) => {
+      should(data).be.undefined();
+      error.toString().should.not.eql('');
+      done();
+    });
+  });
+
+  it("returns an error if a $HOME path isn't resolved", function (done) {
+    const aws = new AwsCredentials();
+
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    delete process.env.HOMEPATH;
+    delete process.env.HOMEDRIVE;
+
+    aws.saveAsIniFile({}, 'profile', (error, data) => {
+      should(data).be.undefined();
+      error.toString().should.not.eql('');
+      done();
+    });
+  });
+});
+
 describe('AwsCredentials#resolveHomePath', function () {
   beforeEach(function () {
     delete process.env.HOME;

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -2,8 +2,23 @@
 
 const AwsCredentials = require('../lib/aws-credentials');
 const should = require('should');
+const Path = require('path');
+const FS = require('fs');
 
 describe('AwsCredentials#saveAsIniFile', function () {
+  const awsFolder = Path.resolve(__dirname, '.aws');
+  const awsCredentials = Path.resolve(awsFolder, 'credentials');
+
+  beforeEach(function () {
+    if (FS.existsSync(awsCredentials)) {
+      FS.unlinkSync(awsCredentials);
+    }
+
+    if (FS.existsSync(awsFolder)) {
+      FS.rmdirSync(awsFolder);
+    }
+  });
+
   it('returns an error when credentials are null', function (done) {
     const aws = new AwsCredentials();
 
@@ -47,6 +62,18 @@ describe('AwsCredentials#saveAsIniFile', function () {
     aws.saveAsIniFile({}, 'profile', (error, data) => {
       should(data).be.undefined();
       error.toString().should.not.eql('');
+      done();
+    });
+  });
+
+  it('creates a $HOME/.aws folder when none exists', function (done) {
+    const aws = new AwsCredentials();
+
+    process.env.HOME = __dirname;
+
+    aws.saveAsIniFile({}, 'profile', (error) => {
+      should(FS.existsSync(awsFolder)).be.true();
+      should(error).be.null();
       done();
     });
   });

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -122,6 +122,24 @@ describe('AwsCredentials#saveAsIniFile', function () {
       done();
     });
   });
+
+  it('saves the session token in the credentials file', function (done) {
+    const aws = new AwsCredentials();
+    const credentials = {
+      SessionToken: 'SessionToken'
+    };
+
+    process.env.HOME = __dirname;
+
+    aws.saveAsIniFile(credentials, 'profile', (error) => {
+      const data = FS.readFileSync(awsCredentials, 'utf-8');
+      const config = ini.parse(data);
+
+      should(error).be.null();
+      should(config.profile.aws_session_token).eql(credentials.SessionToken);
+      done();
+    });
+  });
 });
 
 describe('AwsCredentials#resolveHomePath', function () {

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -4,6 +4,7 @@ const AwsCredentials = require('../lib/aws-credentials');
 const should = require('should');
 const Path = require('path');
 const FS = require('fs');
+const ini = require('ini');
 
 describe('AwsCredentials#saveAsIniFile', function () {
   const awsFolder = Path.resolve(__dirname, '.aws');
@@ -82,6 +83,24 @@ describe('AwsCredentials#saveAsIniFile', function () {
     aws.saveAsIniFile({}, 'profile', (error) => {
       should(FS.statSync(awsFolder).mode & 0x0700).eql(256);
       should(error).be.null();
+      done();
+    });
+  });
+
+  it('saves the access key in the credentials file', function (done) {
+    const aws = new AwsCredentials();
+    const credentials = {
+      AccessKeyId: 'AccessKeyId'
+    };
+
+    process.env.HOME = __dirname;
+
+    aws.saveAsIniFile(credentials, 'profile', (error) => {
+      const data = FS.readFileSync(awsCredentials, 'utf-8');
+      const config = ini.parse(data);
+
+      should(error).be.null();
+      should(config.profile.aws_access_key_id).eql(credentials.AccessKeyId);
       done();
     });
   });

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -4,7 +4,7 @@ const AwsCredentials = require('../lib/aws-credentials');
 const should = require('should');
 
 describe('AwsCredentials#saveAsIniFile', function () {
-  it("returns an error if credentials aren't given", function (done) {
+  it('returns an error when credentials are null', function (done) {
     const aws = new AwsCredentials();
 
     aws.saveAsIniFile(null, 'profile', (error, data) => {
@@ -14,7 +14,7 @@ describe('AwsCredentials#saveAsIniFile', function () {
     });
   });
 
-  it("returns an error if a profile isn't given", function (done) {
+  it('returns an error when profile is null', function (done) {
     const aws = new AwsCredentials();
 
     aws.saveAsIniFile({}, null, (error, data) => {
@@ -24,7 +24,7 @@ describe('AwsCredentials#saveAsIniFile', function () {
     });
   });
 
-  it("returns an error if a $HOME path isn't resolved", function (done) {
+  it('returns an error when $HOME path is unresolved', function (done) {
     const aws = new AwsCredentials();
 
     delete process.env.HOME;

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -158,6 +158,44 @@ describe('AwsCredentials#saveAsIniFile', function () {
       done();
     });
   });
+
+  it('keeps existing profiles', function (done) {
+    const aws = new AwsCredentials();
+    const credentials1 = {
+      AccessKeyId: 'AccessKeyId1',
+      SecretAccessKey: 'SecretAccessKey1',
+      SessionToken: 'SessionToken1'
+    };
+    const credentials2 = {
+      AccessKeyId: 'AccessKeyId2',
+      SecretAccessKey: 'SecretAccessKey2',
+      SessionToken: 'SessionToken2'
+    };
+
+    process.env.HOME = __dirname;
+
+    aws.saveAsIniFile(credentials1, 'profile1', () => {
+      aws.saveAsIniFile(credentials2, 'profile2', () => {
+        const data = FS.readFileSync(awsCredentials, 'utf-8');
+        const config = ini.parse(data);
+
+        should(config.profile1).eql({
+          aws_access_key_id: credentials1.AccessKeyId,
+          aws_secret_access_key: credentials1.SecretAccessKey,
+          aws_session_token: credentials1.SessionToken,
+          aws_security_token: credentials1.SessionToken
+        });
+        should(config.profile2).eql({
+          aws_access_key_id: credentials2.AccessKeyId,
+          aws_secret_access_key: credentials2.SecretAccessKey,
+          aws_session_token: credentials2.SessionToken,
+          aws_security_token: credentials2.SessionToken
+        });
+
+        done();
+      });
+    });
+  });
 });
 
 describe('AwsCredentials#resolveHomePath', function () {

--- a/test/aws-credentials.js
+++ b/test/aws-credentials.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const AwsCredentials = require('../lib/aws-credentials');
+const should = require('should');
+
+describe('AwsCredentials#resolveHomePath', function () {
+  beforeEach(function () {
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    delete process.env.HOMEPATH;
+    delete process.env.HOMEDRIVE;
+  });
+
+  it('returns null if $HOME, $USERPROFILE, and $HOMEPATH are undefined', function () {
+    should(AwsCredentials.resolveHomePath()).be.null();
+  });
+
+  it('uses $HOME if defined', function () {
+    process.env.HOME = 'HOME';
+
+    should(AwsCredentials.resolveHomePath()).eql('HOME');
+  });
+
+  it('uses $USERPROFILE if $HOME is undefined', function () {
+    process.env.USERPROFILE = 'USERPROFILE';
+
+    should(AwsCredentials.resolveHomePath()).eql('USERPROFILE');
+  });
+
+  it('uses $HOMEPATH if $HOME and $USERPROFILE are undefined', function () {
+    process.env.HOMEPATH = 'HOMEPATH';
+
+    should(AwsCredentials.resolveHomePath()).eql('C:/HOMEPATH');
+  });
+
+  it('uses $HOMEDRIVE with $HOMEPATH if defined', function () {
+    process.env.HOMEPATH = 'HOMEPATH';
+    process.env.HOMEDRIVE = 'D:/';
+
+    should(AwsCredentials.resolveHomePath()).eql('D:/HOMEPATH');
+  });
+});


### PR DESCRIPTION
This closes #34 by adding tests around the `AwsCredentials` class. Additionally, it fixes a bug where Awsaml would crash when trying to save AWS credentials if the `$HOME` path wasn't set.