### PR TITLE
Add brew cask file

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ npm run build
 
 Those commnds will create a "dist" folder with zipped binaries.
 
+## Setup on OSX with Homebrew
+A caskfile is bundled with the repository, to install Awsaml with brew simply run:
+
+`brew cask install https://raw.githubusercontent.com/rapid7/awsaml/add_caskfile/brew/cask/awsaml.rb`
+
 ## License
 
 Awsaml is licensed under a MIT License. See the "LICENSE.md" file for more

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,0 +1,13 @@
+cask 'awsaml' do
+  version '1.2.0'
+  sha256 '47d6305bad6de41b95832970cf33d0d1c2e287ce7f0658a9bc6e4b9da307f0b6'
+
+  url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
+  appcast 'https://github.com/rapid7/awsaml/releases.atom',
+          checkpoint: '57a816fdd5e8a7013f4b011671867b6a9de10f80bd1e6e0872baedb955cc0498'
+  name 'awsaml'
+  homepage 'https://github.com/rapid7/awsaml'
+  license :mit
+
+  app 'Awsaml.app'
+end


### PR DESCRIPTION
Add a brew-cask file for awsaml, currently pinned to the 1.2.0 release.

The cask file passes audit and style checks, so it might even be submitted to the main brew repo if you'd like.
