### PR TITLE
Fix #71 - Set data to an empty object if the storage file is empty

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -23,7 +23,12 @@ class Storage {
       this.data = {};
       return;
     }
-    this.data = JSON.parse(fs.readFileSync(this.file, 'utf8'));
+    var json = fs.readFileSync(this.file, 'utf8');
+    if (json === '') {
+      this.data = {};
+      return;
+    }
+    this.data = JSON.parse(json);
   }
 
   /**


### PR DESCRIPTION
This prevents parsing a storage file that is empty (which ends up
throwing a SyntaxError).

cc @emcanearney-r7 who initially found #71.