### PR TITLE
Fix #66 - hide sensitive information by default

### DIFF
--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -49,19 +49,19 @@ class Refresh extends React.Component {
             {this.errorMessage}
             <details>
               <summary>Account ID:</summary>
-              {this.props.accountId}
+              <pre>{this.props.accountId}</pre>
             </details>
             <details>
               <summary>Access Key:</summary>
-              {this.props.accessKey}
+              <pre>{this.props.accessKey}</pre>
             </details>
             <details>
               <summary>Secret Key:</summary>
-              {this.props.secretKey}
+              <pre>{this.props.secretKey}</pre>
             </details>
             <details>
               <summary>Session Token:</summary>
-              {this.props.sessionToken}
+              <pre>{this.props.sessionToken}</pre>
             </details>
             <div className='col-centered rounded-12 content env-var'>
               <p>Run these commands from a {this.term} to use the AWS CLI:</p>

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -52,16 +52,15 @@ class Refresh extends React.Component {
               <pre>{this.props.accountId}</pre>
             </details>
             <details>
-              <summary>Access Key:</summary>
-              <pre>{this.props.accessKey}</pre>
-            </details>
-            <details>
-              <summary>Secret Key:</summary>
-              <pre>{this.props.secretKey}</pre>
-            </details>
-            <details>
-              <summary>Session Token:</summary>
-              <pre>{this.props.sessionToken}</pre>
+              <summary>Access Key, Secret Key, and Session Token:</summary>
+              <dl>
+                <dt>Access Key:</dt>
+                <dd><pre>{this.props.accessKey}</pre></dd>
+                <dt>Secret Key:</dt>
+                <dd><pre>{this.props.secretKey}</pre></dd>
+                <dt>Session Token:</dt>
+                <dd><pre>{this.props.sessionToken}</pre></dd>
+              </dl>
             </details>
             <div className='col-centered rounded-12 content env-var'>
               <p>Run these commands from a {this.term} to use the AWS CLI:</p>

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -47,7 +47,7 @@ class Refresh extends React.Component {
           />
           <div className='col-centered rounded-6 content'>
             {this.errorMessage}
-            <details>
+            <details open>
               <summary>Account ID:</summary>
               <pre>{this.props.accountId}</pre>
             </details>

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -47,16 +47,22 @@ class Refresh extends React.Component {
           />
           <div className='col-centered rounded-6 content'>
             {this.errorMessage}
-            <dl>
-              <dt>Account ID:</dt>
-              <dd>{this.props.accountId}</dd>
-              <dt>Access Key:</dt>
-              <dd>{this.props.accessKey}</dd>
-              <dt>Secret Key:</dt>
-              <dd>{this.props.secretKey}</dd>
-              <dt>Session Token:</dt>
-              <dd>{this.props.sessionToken}</dd>
-            </dl>
+            <details>
+              <summary>Account ID:</summary>
+              {this.props.accountId}
+            </details>
+            <details>
+              <summary>Access Key:</summary>
+              {this.props.accessKey}
+            </details>
+            <details>
+              <summary>Secret Key:</summary>
+              {this.props.secretKey}
+            </details>
+            <details>
+              <summary>Session Token:</summary>
+              {this.props.sessionToken}
+            </details>
             <div className='col-centered rounded-12 content env-var'>
               <p>Run these commands from a {this.term} to use the AWS CLI:</p>
               <pre>

--- a/views/refresh.jsx
+++ b/views/refresh.jsx
@@ -48,11 +48,11 @@ class Refresh extends React.Component {
           <div className='col-centered rounded-6 content'>
             {this.errorMessage}
             <details open>
-              <summary>Account ID:</summary>
+              <summary>Account ID</summary>
               <pre>{this.props.accountId}</pre>
             </details>
             <details>
-              <summary>Access Key, Secret Key, and Session Token:</summary>
+              <summary>Credentials</summary>
               <dl>
                 <dt>Access Key:</dt>
                 <dd><pre>{this.props.accessKey}</pre></dd>


### PR DESCRIPTION
# Motivation and Context
The original issue copied from #66:
> Not that this is a very likely attack vector, but with that window up, someone could capture the information in that window (with a camera? a really good memory?) and then transfer it to another device and use AWS services impersonating me.
>
> Since awsml conveniently writes that data to ~/.aws/credentials already, it also seems unlikely that anyone would really need to copy and paste it from the awsaml GUI to somewhere else.

# Description
We now collapse the access key, secret key, and session token fields by default. The account ID field remains opened by default.

# Screenshot
## Collapsed (default)
<img width="802" alt="screen shot 2016-09-26 at 13 24 22" src="https://cloud.githubusercontent.com/assets/2153375/18834286/fd7f57e6-83ec-11e6-884c-583a215351a2.png">

## Expanded
<img width="784" alt="screen shot 2016-09-26 at 13 24 30" src="https://cloud.githubusercontent.com/assets/2153375/18834285/fd7b5d76-83ec-11e6-8072-e5db2bd8d9d7.png">