### PR TITLE
Fix: Update Homebrew for v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ npm run build
 Those commnds will create a "dist" folder with zipped binaries.
 
 ## Setup on OSX with Homebrew
-A caskfile is bundled with the repository, to install Awsaml with brew simply run:
+A caskfile is bundled with the repository, to install Awsaml with [Homebrew][] simply run:
 
 `brew cask install https://raw.githubusercontent.com/rapid7/awsaml/master/brew/cask/awsaml.rb`
 
@@ -224,3 +224,4 @@ details.
 [NPM]: https://www.npmjs.com
 [saml-provider]: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml.html
 [iam-role]: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html
+[Homebrew]: http://brew.sh/

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -4,7 +4,7 @@ cask 'awsaml' do
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/rapid7/awsaml/releases.atom',
-          checkpoint: '57a816fdd5e8a7013f4b011671867b6a9de10f80bd1e6e0872baedb955cc0498'
+          checkpoint: 'e6d9e30a41aa77bd8cd9248e4f58076d6820f3f733b92a1fa84284d4119aa4b5'
   name 'awsaml'
   homepage 'https://github.com/rapid7/awsaml'
   license :mit

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,5 +1,5 @@
 cask 'awsaml' do
-  version '1.2.0'
+  version '1.3.0'
   sha256 '47d6305bad6de41b95832970cf33d0d1c2e287ce7f0658a9bc6e4b9da307f0b6'
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,6 +1,6 @@
 cask 'awsaml' do
   version '1.3.0'
-  sha256 '47d6305bad6de41b95832970cf33d0d1c2e287ce7f0658a9bc6e4b9da307f0b6'
+  sha256 '4f4459551c3991aed287b02486b8bf0562f6d2fb99e45e93cbe1ee21bc099e0d'
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/rapid7/awsaml/releases.atom',


### PR DESCRIPTION
This updates the Homebrew cask file so it points at the latest v1.3.0 release. It also links to Homebrew in the README so people know where they can get it.