### PR TITLE
Fix: Pin Electron version to 1.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "body-parser": "1.14.1",
     "cookie-parser": "1.4.0",
-    "electron": "1.6.8",
+    "electron": "^1.6.11",
     "electron-packager": "^8.7.0",
     "errorhandler": "1.4.2",
     "express": "4.13.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "body-parser": "1.14.1",
     "cookie-parser": "1.4.0",
-    "electron": "^1.6.8",
+    "electron": "1.6.8",
     "electron-packager": "^8.7.0",
     "errorhandler": "1.4.2",
     "express": "4.13.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "electron-start": "electron .",
     "local-start": "node local.js",
     "prebuild": "rm -rf dist/",
-    "build": "export PLATFORM=${PLATFORM:=darwin,linux,win32}; electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=test --ignore=dist --out=dist --platform=$PLATFORM --arch=x64 --version=0.37.8 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
+    "build": "export PLATFORM=${PLATFORM:=darwin,linux,win32}; electron-packager . Awsaml --asar --ignore=node_modules/electron --ignore=test --ignore=dist --out=dist --platform=$PLATFORM --arch=x64 --app-version=${npm_package_version} --app-bundle-id=com.rapid7.awsaml --helper-bundle-id=com.rapid7.awsaml.helper",
     "postbuild": "for platform in `echo $PLATFORM | sed 's/,/ /g'`; do export platform=$platform; npm run zip; done",
     "zip": "cd dist/Awsaml-${platform}-x64 && zip -q -FS -r ../awsaml-v${npm_package_version}-${platform}-x64.zip .",
     "test": "mocha",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/node@^7.0.18":
+  version "7.0.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.34.tgz#eed5c95291a9dddff6b9f5a72ca342b1e72f0ba2"
+
 abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
@@ -1894,10 +1898,11 @@ electron-to-chromium@^1.2.7:
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.9.tgz#db1cba2a26aebcca2f7f5b8b034554468609157d"
 
-electron@^1.6.8:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.8.tgz#41cbbe7272ccd93339c040f856c0d6372a4ddb07"
+electron@1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.11.tgz#be79c0ebdcefedb5bf28117409800fa53baceffa"
   dependencies:
+    "@types/node" "^7.0.18"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
This fixes #92. I'm explicitly pinning the Electron version in the dependencies section of package.json to 1.6.8 and removing the `--version` flag from the build script. So electron-packager will use the version of Electron it finds in package.json, and we only have one place to change the version number when we want to upgrade Electron.