### PR TITLE
OPS-1 make profileName user configurable

### DIFF
--- a/lib/routes/configure.js
+++ b/lib/routes/configure.js
@@ -42,15 +42,18 @@ module.exports = (app, auth) => {
 
   router.post('/', (req, res) => {
     const metadataUrl = req.body.metadataUrl;
-    const profileName = req.body.profileName;
     const metaDataResponseObj = Object.assign(ResponseObj, {defaultMetadataUrl: metadataUrl});
 
-    let storedMetadataUrls = Storage.get('metadataUrls') || {};
+    let storedMetadataUrls = Storage.get('metadataUrls') || {},
+      profileName = req.body.profileName;
 
-    if (storedMetadataUrls[metadataUrl] && storedMetadataUrls[metadataUrl] !== profileName) {
+    if (profileName === '') {
+      profileName = metadataUrl;
+    }
+
+    if (profileName && storedMetadataUrls[metadataUrl] && storedMetadataUrls[metadataUrl] !== profileName) {
       storedMetadataUrls[metadataUrl] = profileName;
-      Storage.set(storedMetadataUrls)
-
+      Storage.set(storedMetadataUrls);
     }
     app.set('metadataUrl', metadataUrl);
 
@@ -109,8 +112,7 @@ module.exports = (app, auth) => {
           let metadataUrls = Storage.get('metadataUrls') || {};
 
           if (!metadataUrls.hasOwnProperty(metadataUrl)) {
-            metadataUrls[metadataUrl] = profileName || metadataUrl
-
+            metadataUrls[metadataUrl] = profileName || metadataUrl;
             Storage.set('metadataUrls', metadataUrls);
           }
 

--- a/lib/routes/configure.js
+++ b/lib/routes/configure.js
@@ -42,8 +42,16 @@ module.exports = (app, auth) => {
 
   router.post('/', (req, res) => {
     const metadataUrl = req.body.metadataUrl;
+    const profileName = req.body.profileName;
     const metaDataResponseObj = Object.assign(ResponseObj, {defaultMetadataUrl: metadataUrl});
 
+    let storedMetadataUrls = Storage.get('metadataUrls') || {};
+
+    if (storedMetadataUrls[metadataUrl] && storedMetadataUrls[metadataUrl] !== profileName) {
+      storedMetadataUrls[metadataUrl] = profileName;
+      Storage.set(storedMetadataUrls)
+
+    }
     app.set('metadataUrl', metadataUrl);
 
     const xmlReq = https.get(metadataUrl, (xmlRes) => {
@@ -101,7 +109,7 @@ module.exports = (app, auth) => {
           let metadataUrls = Storage.get('metadataUrls') || {};
 
           if (!metadataUrls.hasOwnProperty(metadataUrl)) {
-            metadataUrls[metadataUrl] = metadataUrl
+            metadataUrls[metadataUrl] = profileName || metadataUrl
 
             Storage.set('metadataUrls', metadataUrls);
           }

--- a/lib/routes/configure.js
+++ b/lib/routes/configure.js
@@ -45,7 +45,7 @@ module.exports = (app, auth) => {
     const metaDataResponseObj = Object.assign(ResponseObj, {defaultMetadataUrl: metadataUrl});
 
     let storedMetadataUrls = Storage.get('metadataUrls') || {},
-      profileName = req.body.profileName;
+        profileName = req.body.profileName;
 
     if (profileName === '') {
       profileName = metadataUrl;

--- a/lib/routes/refresh.js
+++ b/lib/routes/refresh.js
@@ -41,8 +41,8 @@ module.exports = (app) => {
       const metadataUrl = app.get('metadataUrl');
       let metadataUrls = Storage.get('metadataUrls');
 
-      // If the stored metadataUrl label value is the same as the URL or empty default to the profile name!
-      if(metadataUrls[metadataUrl] === metadataUrl || !metadataUrls[metadataUrl]) {
+      // If the stored metadataUrl label value is the same as the URL default to the profile name!
+      if(metadataUrls[metadataUrl] === metadataUrl) {
         metadataUrls[metadataUrl] = profileName;
         Storage.set('metadataUrls', metadataUrls);
       }

--- a/lib/routes/refresh.js
+++ b/lib/routes/refresh.js
@@ -41,8 +41,8 @@ module.exports = (app) => {
       const metadataUrl = app.get('metadataUrl');
       let metadataUrls = Storage.get('metadataUrls');
 
-      // If the stored metadataUrl label value is the same as the URL default to the profile name!
-      if(metadataUrls[metadataUrl] === metadataUrl) {
+      // If the stored metadataUrl label value is the same as the URL or empty default to the profile name!
+      if(metadataUrls[metadataUrl] === metadataUrl || !metadataUrls[metadataUrl]) {
         metadataUrls[metadataUrl] = profileName;
         Storage.set('metadataUrls', metadataUrls);
       }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -74,3 +74,9 @@ summary {
 .login-button {
   margin-left: auto;
 }
+
+div.profile {
+  width: 80%;
+  height: 2.5em;
+  line-height: 2.5em;
+}

--- a/views/configure.jsx
+++ b/views/configure.jsx
@@ -66,9 +66,10 @@ class Configure extends React.Component {
 
                   return (
                     <li className='list-group-item' key={key}>
-                      <details>
-                        <summary>{pretty}
-                          <form className='login-button' method='post'>
+                      <form method='post'>
+                        <details>
+                          <summary>
+                            <input name='profileName' type='text' value={pretty} />
                             <input
                               className='form-control'
                               id='metadataUrl'
@@ -76,28 +77,29 @@ class Configure extends React.Component {
                               type='hidden'
                               value={key}
                             />
-                            <span>
-                              <button className='btn btn-default' type='submit'>Login</button>
+                            <span className='login-button'>
+                              <button className='login-button btn btn-default' type='submit'>Login</button>
                             </span>
-                          </form>
 
-                        </summary>
+                          </summary>
 
-                        <br/>
+                          <br/>
 
-                        <div className='input-group'>
-                          <input
-                            className='form-control' defaultValue={key}
-                            name={pretty} readonly // eslint-disable-line react/no-unknown-property
-                          />
-                          <span className='input-group-btn'>
-                            <button
-                              className='btn btn-default copy-to-clipboard-button'
-                              data-clipboard-target={urlSelector}
-                            ><span className='glyphicon glyphicon-copy'/></button>
-                          </span>
-                        </div>
-                      </details>
+                          <div className='input-group'>
+                            <input
+                              className='form-control' defaultValue={key}
+                              name={pretty} readonly // eslint-disable-line react/no-unknown-property
+                            />
+                            <span className='input-group-btn'>
+                              <button
+                                className='btn btn-default copy-to-clipboard-button'
+                                data-clipboard-target={urlSelector}
+                                type='button'
+                              ><span className='glyphicon glyphicon-copy'/></button>
+                            </span>
+                          </div>
+                        </details>
+                      </form>
                     </li>
                   );
                 })

--- a/views/configure.jsx
+++ b/views/configure.jsx
@@ -69,7 +69,9 @@ class Configure extends React.Component {
                       <form method='post'>
                         <details>
                           <summary>
-                            <input name='profileName' type='text' value={pretty} />
+                            <div className='profile'>
+                              <input className='form-control' name='profileName' type='text' value={pretty} />
+                            </div>
                             <input
                               className='form-control'
                               id='metadataUrl'


### PR DESCRIPTION
This allows the user to edit the profileName directly from the ui. This removes the text and replaces it with a input field instead. 

I couldn't get it working with editable text which may be nice instead

![image](https://user-images.githubusercontent.com/15235005/28143384-2af236cc-675d-11e7-9023-5e75bcf2bdd5.png)
