### PR TITLE
Fix: Update Homebrew cask for v1.5.0

### DIFF
--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,10 +1,10 @@
 cask 'awsaml' do
-  version '1.4.0'
+  version '1.5.0'
   sha256 '3f3aa01510627eafead8a205dda2423b3f5c8b36afd4dfc777cdb5781b30fe6b'
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/rapid7/awsaml/releases.atom',
-          checkpoint: '881468e03a4add3ccaac07636e2812a915b14cecd9c66025829e1b7290b98c53'
+          checkpoint: '3d2a662d80c619406bac6682158d8b89320b9d5359863cfbeddd574b00019e9a'
   name 'awsaml'
   homepage 'https://github.com/rapid7/awsaml'
   license :mit

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -7,7 +7,6 @@ cask 'awsaml' do
           checkpoint: '3d2a662d80c619406bac6682158d8b89320b9d5359863cfbeddd574b00019e9a'
   name 'awsaml'
   homepage 'https://github.com/rapid7/awsaml'
-  license :mit
 
   app 'Awsaml.app'
 end

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,6 +1,6 @@
 cask 'awsaml' do
   version '1.5.0'
-  sha256 '3f3aa01510627eafead8a205dda2423b3f5c8b36afd4dfc777cdb5781b30fe6b'
+  sha256 'fd1d22780e47dd13ba2507c9a4661aa259d77e606fb9527a680342414dc6a2aa'
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/rapid7/awsaml/releases.atom',


### PR DESCRIPTION
This updates the `brew/cask/awsaml.rb` file so it installs [v1.5.0](https://github.com/rapid7/awsaml/releases/tag/v1.5.0). Additionally, it removes the `license` stanza as that's no longer supported. Casks with a `license` stanza generate the following error:
```
Warning: Calling Hbc::DSL#license is deprecated!
There is no replacement.
```