### PR TITLE
Refresh credentials every half-duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ dependencies and build Awsaml.
 
 ~~~bash
 rm -rf node_modules/
-yarn install --production
+yarn install
 yarn run build
 ~~~
 

--- a/app.js
+++ b/app.js
@@ -125,5 +125,5 @@ Application.on('ready', () => {
       console.log('Reloading...'); // eslint-disable-line no-console
       mainWindow.loadURL(entryPointUrl);
     }
-  }, (config.aws.duration - 10) * 1000); // eslint-disable-line rapid7/static-magic-numbers
+  }, (config.aws.duration / 2) * 1000); // eslint-disable-line rapid7/static-magic-numbers
 });


### PR DESCRIPTION
By default, credentials last an hour.  Previously, awsaml would refresh
the credentials every hour minus ten seconds.  This leaves the potential
of a long-running command picking up those credentials right before they
expire, and them expiring partway through running the command, and the
command failing.  Terraform is one such example.

This change will refresh the credentials every half hour.  This *should*
guarantee that whenever a command is run, it has at least a half hour of
useful life on the credential that it picks up from the credentials
file.

A bug still exists:  The timer starts from the time awsaml launches, not
from the time a user logs in.  This is okay, because it should still
guarantee more frequent updates than necessary to retain valid and
recent credentials.