### PR TITLE
Fix: Update Homebrew cask for v1.6.1

### DIFF
--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,10 +1,10 @@
 cask 'awsaml' do
-  version '1.5.0'
-  sha256 'fd1d22780e47dd13ba2507c9a4661aa259d77e606fb9527a680342414dc6a2aa'
+  version '1.6.1'
+  sha256 '8840a68b2e1c2ce1fa46a3bb830dd1d2d997e1e7cd49fdc7bcfec40351df97e4'
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/rapid7/awsaml/releases.atom',
-          checkpoint: '3d2a662d80c619406bac6682158d8b89320b9d5359863cfbeddd574b00019e9a'
+          checkpoint: '61fe9e234a69897a47af09aed4c0478e03a1c4e4c874174555db033a14aedea2'
   name 'awsaml'
   homepage 'https://github.com/rapid7/awsaml'
 


### PR DESCRIPTION
```
$ shasum -a 256 awsaml-v1.6.1-darwin-x64.zip
8840a68b2e1c2ce1fa46a3bb830dd1d2d997e1e7cd49fdc7bcfec40351df97e4  awsaml-v1.6.1-darwin-x64.zip
$ brew cask _appcast_checkpoint --calculate 'https://github.com/rapid7/awsaml/releases.atom'
61fe9e234a69897a47af09aed4c0478e03a1c4e4c874174555db033a14aedea2
```