### PR TITLE
Added workaround for the SAML exception error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/.aws/
 test/data/test.json
 typings/
 coverage/
+*~

--- a/app-menu.js
+++ b/app-menu.js
@@ -44,6 +44,13 @@ const template = [{
       }
     }
   }, {
+      label: 'Reset',
+      click(item, focusedWindow) {
+          if (focusedWindow) {
+              focusedWindow.emit('reset');
+          }
+      }
+  }, {
     label: 'Toggle Full Screen',
     accelerator: (function a() {
       return (process.platform === 'darwin') ? 'Ctrl+Command+F' : 'F11';

--- a/app-menu.js
+++ b/app-menu.js
@@ -44,12 +44,12 @@ const template = [{
       }
     }
   }, {
-      label: 'Reset',
-      click(item, focusedWindow) {
-          if (focusedWindow) {
-              focusedWindow.emit('reset');
-          }
+    label: 'Reset',
+    click(item, focusedWindow) {
+      if (focusedWindow) {
+        focusedWindow.emit('reset');
       }
+    }
   }, {
     label: 'Toggle Full Screen',
     accelerator: (function a() {

--- a/app.js
+++ b/app.js
@@ -109,12 +109,18 @@ Application.on('ready', () => {
     mainWindow = null;
   });
 
-  mainWindow.loadURL(Server.get('configureUrl'));
-  mainWindow.show();
+  mainWindow.on('reset', () => {
+      setImmediate(() => {
+          mainWindow.loadURL(Server.get('configureUrl'));
+          mainWindow.show();
+      });
+  });
+
   mainWindow.webContents.on('did-finish-load', () => {
     return loadTouchBar(mainWindow);
   });
 
+  mainWindow.emit('reset');
   // TODO: A global clipboard instance must be loaded. Investigate how to load it within the .jsx code.
   mainWindow.webContents.executeJavaScript('new Clipboard(".copy-to-clipboard-button");');
 

--- a/app.js
+++ b/app.js
@@ -110,10 +110,10 @@ Application.on('ready', () => {
   });
 
   mainWindow.on('reset', () => {
-      setImmediate(() => {
-          mainWindow.loadURL(Server.get('configureUrl'));
-          mainWindow.show();
-      });
+    setImmediate(() => {
+      mainWindow.loadURL(Server.get('configureUrl'));
+      mainWindow.show();
+    });
   });
 
   mainWindow.webContents.on('did-finish-load', () => {


### PR DESCRIPTION
Added workaround for the SAML exception error where sometimes the client gets into a SAML error state and doesn't work anymore. This adds a new option 'Reset' to the View menu which brings you back to the initial login/configuration page.