### PR TITLE
Fix update homebrew cask for v2.0.0

### DIFF
--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,6 +1,6 @@
 cask 'awsaml' do
-  version '1.6.1'
   sha256 '8840a68b2e1c2ce1fa46a3bb830dd1d2d997e1e7cd49fdc7bcfec40351df97e4'
+  version '2.0.0'
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/rapid7/awsaml/releases.atom',

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,6 +1,6 @@
 cask 'awsaml' do
-  sha256 '8840a68b2e1c2ce1fa46a3bb830dd1d2d997e1e7cd49fdc7bcfec40351df97e4'
   version '2.0.0'
+  sha256 'cea42994cb52a71b8f811c38b25281604360b8216889e0f3217d4583cd7ead1a'
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/rapid7/awsaml/releases.atom',

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -4,7 +4,7 @@ cask 'awsaml' do
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/rapid7/awsaml/releases.atom',
-          checkpoint: '61fe9e234a69897a47af09aed4c0478e03a1c4e4c874174555db033a14aedea2'
+          checkpoint: '786054d12bd083162881c42f3ec651187044c9d8ea5e30b485d6cba3c6e04c8c'
   name 'awsaml'
   homepage 'https://github.com/rapid7/awsaml'
 


### PR DESCRIPTION
This updates the `brew/cask/awsaml.rb` file so it installs [v2.0.0](https://github.com/rapid7/awsaml/releases/tag/v2.0.0).