### PR TITLE
Add multiple role support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,24 @@ Replace the "arn:aws:iam:role" value with the ARN of the role in AWS you
 created. Replace the "arn:aws:iam:provider" value with the ARN of the identity
 provider in AWS your created.
 
+
+##### Multiple Role Support
+To support multiple roles, add multiple values to the `https://aws.amazon.com/SAML/Attributes/Role`
+attribute.  For example:
+
+```
+arn:aws:iam:role1,arn:aws:iam:provider
+arn:aws:iam:role2,arn:aws:iam:provider
+arn:aws:iam:role3,arn:aws:iam:provider
+```
+
+*Special note for Okta users*:  Multiple roles must be passed as multiple values to a single
+attribute key.  By default, Okta serializes multiple values into a single value using commas.
+To support multiple roles, you must contact Okta support and request that the
+`SAML_SUPPORT_ARRAY_ATTRIBUTES` feature flag be enabled on your Okta account.  For more details
+see [this post](https://devforum.okta.com/t/multivalued-attributes/179).
+
+
 ### 5. Run Awsaml and give it your application's metadata.
 You can find a prebuilt binary for Awsaml on [the releases page][releases]. Grab
 the appropriate binary for your architecture and run the Awsaml application. It

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -8,7 +8,13 @@ module.exports = (app, auth) => {
     failureFlash: true,
     failureRedirect: app.get('configureUrl'),
   }), (req, res) => {
-    const arns = req.user['https://aws.amazon.com/SAML/Attributes/Role'].split(',');
+
+    roles = req.user['https://aws.amazon.com/SAML/Attributes/Role']
+    if (!Array.isArray(roles)) {
+      roles = [roles]
+    }
+
+    const arns = roles[0].split(',');
 
     /* eslint-disable no-param-reassign */
     req.session.passport.samlResponse = req.body.SAMLResponse;

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -18,15 +18,18 @@ module.exports = (app, auth) => {
       roleAttr = [roleAttr];
     }
 
-    const roles = roleAttr.map((attr, i) => {
-      const arns = attr.split(',');
+    const roles = roleAttr.map((arns, i) => {
+      const [roleArn, principalArn] = arns.split(',');
+      const roleArnSegments = roleArn.split(':');
+      const accountId = roleArnSegments[4];
+      const roleName = roleArnSegments[5].replace('role/', '');
 
       return {
-        accountId: arns[0].split(':')[4],
+        accountId,
         index: i,
-        principalArn: arns[1],
-        roleArn: arns[0],
-        roleName: arns[0].split(':')[5].replace('role/', ''),
+        principalArn,
+        roleArn,
+        roleName,
       };
     });
 

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -18,8 +18,8 @@ module.exports = (app, auth) => {
       roleAttr = [roleAttr];
     }
 
-    let roles = roleAttr.map((attr, i) => {
-      let arns = attr.split(',');
+    const roles = roleAttr.map((attr, i) => {
+      const arns = attr.split(',');
 
       return {
         accountId: arns[0].split(':')[4],
@@ -40,7 +40,7 @@ module.exports = (app, auth) => {
       // the latest roles from the current SAML assertion.  If it
       // doesn't match, wipe it from the session.
       if (session.roleArn && session.principalArn) {
-        let found = roles.find((role) =>
+        const found = roles.find((role) =>
           role.roleArn === session.roleArn && role.principalArn === session.principalArn
         );
 
@@ -61,7 +61,7 @@ module.exports = (app, auth) => {
         frontend.searchParams.set('select-role', 'true');
       }
     } else {
-      let role = roles[0];
+      const role = roles[0];
 
       frontend.searchParams.set('auth', 'true');
 

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -9,23 +9,67 @@ module.exports = (app, auth) => {
     failureRedirect: app.get('configureUrl'),
   }), (req, res) => {
 
-    roles = req.user['https://aws.amazon.com/SAML/Attributes/Role']
-    if (!Array.isArray(roles)) {
-      roles = [roles]
+    roleAttr = req.user['https://aws.amazon.com/SAML/Attributes/Role']
+    if (!Array.isArray(roleAttr)) {
+      roleAttr = [roleAttr]
     }
 
-    const arns = roles[0].split(',');
+    let roles = roleAttr.map( (attr, i) => {
+      let arns = attr.split(',');
+      return {
+        index: i,
+        roleArn: arns[0],
+        roleName: arns[0].split(':')[5].replace('role/', ''),
+        principalArn: arns[1],
+        accountId: arns[0].split(':')[4],
+      }
+    });
 
-    /* eslint-disable no-param-reassign */
-    req.session.passport.samlResponse = req.body.SAMLResponse;
-    req.session.passport.roleArn = arns[0];
-    req.session.passport.principalArn = arns[1];
-    req.session.passport.accountId = arns[0].split(':')[4]; // eslint-disable-line rapid7/static-magic-numbers
-    /* eslint-enable no-param-reassign */
+    const session = req.session.passport;
+    session.samlResponse = req.body.SAMLResponse;
+    session.roles = roles;
+
     let frontend = process.env.ELECTRON_START_URL || app.get('baseUrl');
-
     frontend = new url.URL(frontend);
-    frontend.searchParams.set('auth', 'true');
+
+    if (roles.length > 1) {
+      // If the session has a previous role, see if it matches
+      // the latest roles from the current SAML assertion.  If it
+      // doesn't match, wipe it from the session.
+      if (session.roleArn && session.principalArn) {
+        let found = roles.find(role => {
+          return role.roleArn === session.roleArn &&
+            role.principalArn === session.principalArn;
+        });
+
+        if (!found) {
+          session.showRole = undefined;
+          session.roleArn = undefined;
+          session.roleName = undefined;
+          session.principalArn = undefined;
+          session.accountId = undefined;
+        }
+      }
+
+      // If the session still has a previous role, proceed directly to auth.
+      // Otherwise ask the user to select a role.
+      if (session.roleArn && session.principalArn && session.roleName && session.accountId) {
+        frontend.searchParams.set('auth', 'true');
+      } else {
+        frontend.searchParams.set('select-role', 'true');
+      }
+
+    } else {
+      frontend.searchParams.set('auth', 'true');
+
+      let role = roles[0];
+      session.showRole = false;
+      session.roleArn = role.roleArn;
+      session.roleName = role.roleName;
+      session.principalArn = role.principalArn;
+      session.accountId = role.accountId;
+    }
+
     res.redirect(frontend);
   });
 

--- a/api/routes/configure.js
+++ b/api/routes/configure.js
@@ -21,7 +21,7 @@ module.exports = (app, auth) => {
     // profile deletes/edits a little safer since they will no longer be
     // based on the iteration index.
     let migrated = false;
-    const storedMetadataUrls = Storage.get('metadataUrls', []).map((metadata) => {
+    const storedMetadataUrls = (Storage.get('metadataUrls') || []).map((metadata) => {
       if (metadata.profileUuid === undefined) {
         migrated = true;
         metadata.profileUuid = uuidv4();

--- a/api/routes/configure.js
+++ b/api/routes/configure.js
@@ -17,19 +17,19 @@ const ResponseObj = require('./../response');
 
 module.exports = (app, auth) => {
   router.get('/', (req, res) => {
-    const storedMetadataUrls = Storage.get('metadataUrls') || [];
-
     // Migrate metadataUrls to include a profileUuid.  This makes
     // profile deletes/edits a little safer since they will no longer be
     // based on the iteration index.
     let migrated = false;
-
-    storedMetadataUrls.forEach((metadata) => {
+    const storedMetadataUrls = Storage.get('metadataUrls', []).map((metadata) => {
       if (metadata.profileUuid === undefined) {
         migrated = true;
         metadata.profileUuid = uuidv4();
       }
+
+      return metadata;
     });
+
     if (migrated) {
       Storage.set('metadataUrls', storedMetadataUrls);
     }

--- a/api/routes/refresh.js
+++ b/api/routes/refresh.js
@@ -44,10 +44,9 @@ module.exports = (app) => {
 
       const profileName = `awsaml-${session.accountId}`;
       const metadataUrl = app.get('metadataUrl');
-      const metadataUrls = Storage.get('metadataUrls', []);
 
       // Update the stored profile with account number(s) and profile names
-      metadataUrls.forEach((metadata) => {
+      const metadataUrls = Storage.get('metadataUrls', []).map((metadata) => {
         if (metadata.url === metadataUrl) {
           // If the stored metadataUrl label value is the same as the URL
           // default to the profile name!
@@ -56,7 +55,10 @@ module.exports = (app) => {
           }
           metadata.roles = session.roles.map((role) => role.roleArn);
         }
+
+        return metadata;
       });
+
       Storage.set('metadataUrls', metadataUrls);
 
       // Fetch the metadata profile name for this URL

--- a/api/routes/refresh.js
+++ b/api/routes/refresh.js
@@ -20,6 +20,8 @@ module.exports = (app) => {
 
     const refreshResponseObj = Object.assign({}, ResponseObj, {
       accountId: session.accountId,
+      roleName: session.roleName,
+      showRole: session.showRole,
     });
 
     sts.assumeRoleWithSAML({

--- a/api/routes/refresh.js
+++ b/api/routes/refresh.js
@@ -44,15 +44,19 @@ module.exports = (app) => {
 
       const profileName = `awsaml-${session.accountId}`;
       const metadataUrl = app.get('metadataUrl');
-      // If the stored metadataUrl label value is the same as the URL default to the profile name!
-      const metadataUrls = Storage.get('metadataUrls', []).map((storedMetadataUrl) => {
-        if (storedMetadataUrl.url === metadataUrl && storedMetadataUrl.name === metadataUrl) {
-          storedMetadataUrl.name = profileName;
+      const metadataUrls = Storage.get('metadataUrls', []);
+
+      // Update the stored profile with account number(s) and profile names
+      metadataUrls.forEach((metadata) => {
+        if (metadata.url === metadataUrl) {
+          // If the stored metadataUrl label value is the same as the URL
+          // default to the profile name!
+          if (metadata.name === metadataUrl) {
+            metadata.name = profileName;
+          }
+          metadata.roles = session.roles.map((role) => role.roleArn);
         }
-
-        return storedMetadataUrl;
       });
-
       Storage.set('metadataUrls', metadataUrls);
 
       // Fetch the metadata profile name for this URL

--- a/api/routes/refresh.js
+++ b/api/routes/refresh.js
@@ -46,7 +46,7 @@ module.exports = (app) => {
       const metadataUrl = app.get('metadataUrl');
 
       // Update the stored profile with account number(s) and profile names
-      const metadataUrls = Storage.get('metadataUrls', []).map((metadata) => {
+      const metadataUrls = (Storage.get('metadataUrls') || []).map((metadata) => {
         if (metadata.url === metadataUrl) {
           // If the stored metadataUrl label value is the same as the URL
           // default to the profile name!

--- a/api/routes/refresh.js
+++ b/api/routes/refresh.js
@@ -55,6 +55,11 @@ module.exports = (app) => {
 
       Storage.set('metadataUrls', metadataUrls);
 
+      // Fetch the metadata profile name for this URL
+      const profile = metadataUrls.find((metadata) => metadata.url === metadataUrl);
+
+      credentialResponseObj.profileName = profile.name;
+
       credentials.save(data.Credentials, profileName, (credSaveErr) => {
         if (credSaveErr) {
           res.json(Object.assign({}, credentialResponseObj, {

--- a/api/routes/select-role.js
+++ b/api/routes/select-role.js
@@ -26,7 +26,7 @@ module.exports = () => {
       });
     }
 
-    if (!req.body.index) {
+    if (req.body.index === undefined) {
       return res.status(422).json({
         error: 'Missing role',
       });

--- a/api/routes/select-role.js
+++ b/api/routes/select-role.js
@@ -1,7 +1,8 @@
 const express = require('express');
+
 const router = express.Router();
 
-module.exports = (app) => {
+module.exports = () => {
   router.get('/', (req, res) => {
     const session = req.session.passport;
 

--- a/api/routes/select-role.js
+++ b/api/routes/select-role.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const router = express.Router();
+
+module.exports = (app) => {
+  router.get('/', (req, res) => {
+    const session = req.session.passport;
+
+    if (session === undefined) {
+      return res.status(401).json({
+        error: 'Invalid session',
+      });
+    }
+
+    res.json({
+      roles: session.roles,
+    });
+  });
+
+  router.post('/', (req, res) => {
+    const session = req.session.passport;
+
+    if (session === undefined) {
+      return res.status(401).json({
+        error: 'Invalid session',
+      });
+    }
+
+    if (req.body.index === undefined) {
+      return res.status(422).json({
+        error: 'Missing role',
+      });
+    }
+
+    let role = session.roles[req.body.index];
+
+    session.showRole = true;
+    session.roleArn = role.roleArn;
+    session.roleName = role.roleName;
+    session.principalArn = role.principalArn;
+    session.accountId = role.accountId;
+
+    res.json({
+      status: 'selected',
+    });
+  });
+
+  return router;
+};

--- a/api/routes/select-role.js
+++ b/api/routes/select-role.js
@@ -6,7 +6,7 @@ module.exports = () => {
   router.get('/', (req, res) => {
     const session = req.session.passport;
 
-    if (session === undefined) {
+    if (!session) {
       return res.status(401).json({
         error: 'Invalid session',
       });
@@ -20,19 +20,19 @@ module.exports = () => {
   router.post('/', (req, res) => {
     const session = req.session.passport;
 
-    if (session === undefined) {
+    if (!session) {
       return res.status(401).json({
         error: 'Invalid session',
       });
     }
 
-    if (req.body.index === undefined) {
+    if (!req.body.index) {
       return res.status(422).json({
         error: 'Missing role',
       });
     }
 
-    let role = session.roles[req.body.index];
+    const role = session.roles[req.body.index];
 
     session.showRole = true;
     session.roleArn = role.roleArn;

--- a/api/server.js
+++ b/api/server.js
@@ -23,6 +23,9 @@ const app = require('./server-config')(auth, config, sessionSecret);
     name: '/profile',
     route: require('./routes/profile')(),
   }, {
+    name: '/select-role',
+    route: require('./routes/select-role')(),
+  }, {
     name: '/',
     route: require('./routes/static')(),
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "electron": "electron electron/electron.js",
-    "electron-dev": "NODE_ENV=development; ELECTRON_START_URL=http://localhost:3000 electron electron/electron.js",
+    "electron-dev": "NODE_ENV=development ELECTRON_START_URL=http://localhost:3000 electron electron/electron.js",
     "react-start": "BROWSER=none; NODE_ENV=development react-scripts start",
     "react-build": "react-scripts build",
     "test": "mocha",

--- a/src/actions/select-role.js
+++ b/src/actions/select-role.js
@@ -1,0 +1,49 @@
+import {createAction} from 'redux-actions';
+import * as api from '../apis';
+
+export const FETCH_SELECT_ROLE_REQUEST = 'FETCH_SELECT_ROLE_REQUEST';
+export const FETCH_SELECT_ROLE_SUCCESS = 'FETCH_SELECT_ROLE_SUCCESS';
+export const FETCH_SELECT_ROLE_FAILURE = 'FETCH_SELECT_ROLE_FAILURE';
+export const SUBMIT_SELECT_ROLE_REQUEST = 'SUBMIT_SELECT_ROLE_REQUEST';
+export const SUBMIT_SELECT_ROLE_SUCCESS = 'SUBMIT_SELECT_ROLE_SUCCESS';
+export const SUBMIT_SELECT_ROLE_FAILURE = 'SUBMIT_SELECT_ROLE_FAILURE';
+
+const fetchSelectRoleRequest = createAction(FETCH_SELECT_ROLE_REQUEST);
+const fetchSelectRoleSuccess = createAction(FETCH_SELECT_ROLE_SUCCESS);
+const fetchSelectRoleFailure = createAction(FETCH_SELECT_ROLE_FAILURE);
+
+export const fetchSelectRole = () => async (dispatch) => {
+  dispatch(fetchSelectRoleRequest());
+
+  try {
+    const data = await api.getSelectRole();
+
+    if (data.error) {
+      return dispatch(fetchSelectRoleFailure(data));
+    }
+
+    return dispatch(fetchSelectRoleSuccess(data));
+  } catch (err) {
+    return dispatch(fetchSelectRoleFailure(err));
+  }
+};
+
+const submitSelectRoleRequest = createAction(SUBMIT_SELECT_ROLE_REQUEST);
+const submitSelectRoleSuccess = createAction(SUBMIT_SELECT_ROLE_SUCCESS);
+const submitSelectRoleFailure = createAction(SUBMIT_SELECT_ROLE_FAILURE);
+
+export const submitSelectRole = (payload) => async (dispatch) => {
+  dispatch(submitSelectRoleRequest());
+
+  try {
+    const data = await api.postSelectRole(payload);
+
+    if (data.error) {
+      return dispatch(submitSelectRoleFailure(data));
+    }
+
+    return dispatch(submitSelectRoleSuccess(data));
+  } catch (err) {
+    return dispatch(submitSelectRoleFailure(err));
+  }
+};

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,8 +1,6 @@
 import axios from 'axios';
-import {ENDPOINTS} from '../constants';
 
 const axiosClient = axios.create({
-  baseURL: ENDPOINTS.electron,
   timeout: 30000,
 });
 

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -40,6 +40,27 @@ export const getRefresh = async () => {
 };
 
 /**
+ * Execute GET request against the /select-role endpoint
+ * @returns {Promise<*>}
+ */
+export const getSelectRole = async () => {
+  const {data} = await axiosClient.get('select-role');
+
+  return data;
+};
+
+/**
+ * Execute POST request against the /select-role endpoint with payload
+ * @param {Object} payload
+ * @returns {Promise<*>}
+ */
+export const postSelectRole = async (payload) => {
+  const {data} = await axiosClient.post('select-role', payload);
+
+  return data;
+};
+
+/**
  * Execute GET request against the SPA /logout endpoint
  *
  * Note: this call triggers the /logout route on the SPA to make sure that

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,0 @@
-export const ENDPOINTS = {
-  electron: 'http://localhost:2600',
-};

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -7,6 +7,7 @@ import {
 
 import Configure from './configure/Configure';
 import Refresh from './refresh/Refresh';
+import SelectRole from './select-role/SelectRole';
 import ErrorBoundary from './ErrorBoundary';
 import DebugRoute from './components/DebugRoute';
 
@@ -28,6 +29,10 @@ class App extends Component {
           <Route
             component={Refresh}
             path="/refresh"
+          />
+          <Route
+            component={SelectRole}
+            path="/select-role"
           />
           {debug ? <Route component={DebugRoute} /> : ''}
         </Switch>

--- a/src/containers/components/InputGroupWithCopyButton.js
+++ b/src/containers/components/InputGroupWithCopyButton.js
@@ -13,16 +13,16 @@ export class InputGroupWithCopyButton extends Component {
   static propTypes = {
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     message: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    multiLine: PropTypes.bool,
     name: PropTypes.string.isRequired,
     readOnly: PropTypes.bool,
     value: PropTypes.string.isRequired,
-    multiLine: PropTypes.bool,
   };
 
   static defaultProps = {
     message: 'Copied!',
-    readOnly: true,
     multiLine: false,
+    readOnly: true,
   };
 
   state = {
@@ -52,8 +52,8 @@ export class InputGroupWithCopyButton extends Component {
           id={name}
           name={name}
           readOnly={readOnly}
+          type={multiLine ? 'textarea' : 'text'}
           value={value}
-          type={multiLine ? "textarea" : "text"}
         />
         <InputGroupAddon
           addonType="append"

--- a/src/containers/components/InputGroupWithCopyButton.js
+++ b/src/containers/components/InputGroupWithCopyButton.js
@@ -45,7 +45,17 @@ export class InputGroupWithCopyButton extends Component {
   };
 
   render() {
-    const {id: idFromProps, buttonClassName, className, inputClassName, name, readOnly, value, message, multiLine} = this.props;
+    const {
+      id: idFromProps,
+      buttonClassName,
+      className,
+      inputClassName,
+      name,
+      readOnly,
+      value,
+      message,
+      multiLine,
+    } = this.props;
     const id = `icon-${idFromProps}`;
 
     return (

--- a/src/containers/components/InputGroupWithCopyButton.js
+++ b/src/containers/components/InputGroupWithCopyButton.js
@@ -16,11 +16,13 @@ export class InputGroupWithCopyButton extends Component {
     name: PropTypes.string.isRequired,
     readOnly: PropTypes.bool,
     value: PropTypes.string.isRequired,
+    multiLine: PropTypes.bool,
   };
 
   static defaultProps = {
     message: 'Copied!',
     readOnly: true,
+    multiLine: false,
   };
 
   state = {
@@ -40,7 +42,7 @@ export class InputGroupWithCopyButton extends Component {
   };
 
   render() {
-    const {id: idFromProps, name, readOnly, value, message} = this.props;
+    const {id: idFromProps, name, readOnly, value, message, multiLine} = this.props;
     const id = `icon-${idFromProps}`;
 
     return (
@@ -51,6 +53,7 @@ export class InputGroupWithCopyButton extends Component {
           name={name}
           readOnly={readOnly}
           value={value}
+          type={multiLine ? "textarea" : "text"}
         />
         <InputGroupAddon
           addonType="append"

--- a/src/containers/components/InputGroupWithCopyButton.js
+++ b/src/containers/components/InputGroupWithCopyButton.js
@@ -11,7 +11,10 @@ import Clipboard from 'react-clipboard.js';
 
 export class InputGroupWithCopyButton extends Component {
   static propTypes = {
+    buttonClassName: PropTypes.string,
+    className: PropTypes.string,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    inputClassName: PropTypes.string,
     message: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     multiLine: PropTypes.bool,
     name: PropTypes.string.isRequired,
@@ -42,13 +45,13 @@ export class InputGroupWithCopyButton extends Component {
   };
 
   render() {
-    const {id: idFromProps, name, readOnly, value, message, multiLine} = this.props;
+    const {id: idFromProps, buttonClassName, className, inputClassName, name, readOnly, value, message, multiLine} = this.props;
     const id = `icon-${idFromProps}`;
 
     return (
-      <InputGroup>
+      <InputGroup className={className}>
         <Input
-          className="form-control"
+          className={`form-control ${inputClassName}`}
           id={name}
           name={name}
           readOnly={readOnly}
@@ -69,7 +72,7 @@ export class InputGroupWithCopyButton extends Component {
             {message}
           </Tooltip>
           <Clipboard
-            className="btn btn-outline-secondary copy-to-clipboard-button"
+            className={`btn btn-outline-secondary copy-to-clipboard-button ${buttonClassName}`}
             data-clipboard-text={value}
           >
             <FontAwesomeIcon icon={['far', 'copy']}/>

--- a/src/containers/components/InputGroupWithCopyButton.js
+++ b/src/containers/components/InputGroupWithCopyButton.js
@@ -46,7 +46,7 @@ export class InputGroupWithCopyButton extends Component {
     const id = `icon-${idFromProps}`;
 
     return (
-      <InputGroup className="mb-3 mt-3">
+      <InputGroup>
         <Input
           className="form-control"
           id={name}

--- a/src/containers/configure/Configure.js
+++ b/src/containers/configure/Configure.js
@@ -42,8 +42,8 @@ class Configure extends Component {
 
     this.state = {
       auth: (params['?auth'] && params['?auth'] === 'true'),
-      selectRole: (params['?select-role'] && params['?select-role'] === 'true'),
       loaded: false,
+      selectRole: (params['?select-role'] && params['?select-role'] === 'true'),
     };
   }
 

--- a/src/containers/configure/Configure.js
+++ b/src/containers/configure/Configure.js
@@ -42,6 +42,7 @@ class Configure extends Component {
 
     this.state = {
       auth: (params['?auth'] && params['?auth'] === 'true'),
+      selectRole: (params['?select-role'] && params['?select-role'] === 'true'),
       loaded: false,
     };
   }
@@ -64,6 +65,9 @@ class Configure extends Component {
   render() {
     if (this.state.auth) {
       return <Redirect to="/refresh" />;
+    }
+    if (this.state.selectRole) {
+      return <Redirect to="/select-role" />;
     }
     const metadataUrls = getOr([], 'metadataUrls', this.props);
 

--- a/src/containers/configure/Login.js
+++ b/src/containers/configure/Login.js
@@ -54,6 +54,7 @@ class LoginComponent extends Component {
     const payload = {
       metadataUrl: this.props.url,
       profileName: profileName ? profileName : this.props.pretty,
+      profileUuid: this.props.profileUuid,
     };
 
     this.props.submitConfigure(payload);

--- a/src/containers/configure/RecentLogins.js
+++ b/src/containers/configure/RecentLogins.js
@@ -44,10 +44,24 @@ const filterMetadataUrls = (metadataUrls, filterText) => {
   const tokens = filterText.split(' ').map((token) => token.toLowerCase());
 
   return metadataUrls.filter((metadataUrl) =>
-    tokens.every((token) =>
-      metadataUrl.name.toLowerCase().indexOf(token) !== -1
-        || metadataUrl.url.toLowerCase().indexOf(token) !== -1
-    )
+    tokens.every((token) => {
+      // Compare profile name
+      if (metadataUrl.name.toLowerCase().indexOf(token) !== -1) {
+        return true;
+      }
+
+      // Compare profile URL
+      if (metadataUrl.url.toLowerCase().indexOf(token) !== -1) {
+        return true;
+      }
+
+      // Compare profile roles
+      if ((metadataUrl.roles || []).some((role) => role.toLowerCase().indexOf(token) !== -1)) {
+        return true;
+      }
+
+      return false;
+    })
   );
 };
 

--- a/src/containers/refresh/Credentials.js
+++ b/src/containers/refresh/Credentials.js
@@ -16,11 +16,17 @@ const CredProps = styled.dl`
 
 const CredPropsKey = styled.dt`
   grid-column: 1;
-  margin-right: .5rem;
+  margin-right: 1rem;
+  margin-bottom: 10px;
+  line-height: 2.5rem;
 `;
 
 const CredPropsVal = styled.dd`
   grid-column: 2;
+`;
+
+const SmallMarginCardBody = styled(CardBody)`
+  padding: 1.25rem 0.5rem;
 `;
 
 export const Credentials = ({awsAccessKey, awsSecretKey, awsSessionToken}) => {
@@ -42,7 +48,7 @@ export const Credentials = ({awsAccessKey, awsSecretKey, awsSessionToken}) => {
     <details>
       <summary>Credentials</summary>
       <Card>
-        <CardBody className="bg-light">
+        <SmallMarginCardBody className="bg-light">
           <CredProps>
             {
               Array.from(creds).map(([name, value]) => {
@@ -61,7 +67,7 @@ export const Credentials = ({awsAccessKey, awsSecretKey, awsSessionToken}) => {
               })
             }
           </CredProps>
-        </CardBody>
+        </SmallMarginCardBody>
       </Card>
     </details>
   );

--- a/src/containers/refresh/Credentials.js
+++ b/src/containers/refresh/Credentials.js
@@ -4,7 +4,24 @@ import {
   CardBody
 } from 'reactstrap';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import {InputGroupWithCopyButton} from '../components/InputGroupWithCopyButton';
+
+const CredProps = styled.dl`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  margin: 0;
+  padding: .5rem;
+`;
+
+const CredPropsKey = styled.dt`
+  grid-column: 1;
+  margin-right: .5rem;
+`;
+
+const CredPropsVal = styled.dd`
+  grid-column: 2;
+`;
 
 export const Credentials = ({awsAccessKey, awsSecretKey, awsSessionToken}) => {
   const creds = new Map();
@@ -26,40 +43,24 @@ export const Credentials = ({awsAccessKey, awsSecretKey, awsSessionToken}) => {
       <summary>Credentials</summary>
       <Card>
         <CardBody className="bg-light">
-          <dl
-            className="mb-0"
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'auto 1fr',
-            }}
-          >
+          <CredProps>
             {
               Array.from(creds).map(([name, value]) => {
                 const id = name.toLowerCase().split(' ').join('-');
 
                 return ([
-                  <dt
-                    className="mr-2"
-                    key={`creds-dt-${name}`}
-                    style={{gridColumn: 1}}
-                  >
-                    {name}:
-                  </dt>,
-                  <dd
-                    key={`creds-dd-${name}`}
-                    style={{gridColumn: 2}}
-                  >
+                  <CredPropsKey key={`creds-dt-${name}`}>{name}:</CredPropsKey>,
+                  <CredPropsVal key={`creds-dd-${name}`}>
                     <InputGroupWithCopyButton
                       id={id}
                       name={`input-${id}`}
                       value={value}
                     />
-                  </dd>,
+                  </CredPropsVal>,
                 ]);
               })
             }
-
-          </dl>
+          </CredProps>
         </CardBody>
       </Card>
     </details>

--- a/src/containers/refresh/Credentials.js
+++ b/src/containers/refresh/Credentials.js
@@ -26,20 +26,35 @@ export const Credentials = ({awsAccessKey, awsSecretKey, awsSessionToken}) => {
       <summary>Credentials</summary>
       <Card>
         <CardBody className="bg-light">
-          <dl className="mb-0" style={{display: 'grid', gridTemplateColumns: 'auto 1fr'}}>
+          <dl
+            className="mb-0"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'auto 1fr',
+            }}
+          >
             {
               Array.from(creds).map(([name, value]) => {
                 const id = name.toLowerCase().split(' ').join('-');
 
                 return ([
-                    <dt key={'creds-dt-'+name} className="mr-2" style={{gridColumn: 1}}>{name}:</dt>,
-                    <dd key={'creds-dd-'+name} style={{gridColumn: 2}}>
-                      <InputGroupWithCopyButton
-                        id={id}
-                        name={`input-${id}`}
-                        value={value}
-                      />
-                    </dd>
+                  <dt
+                    className="mr-2"
+                    key={`creds-dt-${name}`}
+                    style={{gridColumn: 1}}
+                  >
+                    {name}:
+                  </dt>,
+                  <dd
+                    key={`creds-dd-${name}`}
+                    style={{gridColumn: 2}}
+                  >
+                    <InputGroupWithCopyButton
+                      id={id}
+                      name={`input-${id}`}
+                      value={value}
+                    />
+                  </dd>,
                 ]);
               })
             }

--- a/src/containers/refresh/Credentials.js
+++ b/src/containers/refresh/Credentials.js
@@ -25,24 +25,22 @@ export const Credentials = ({awsAccessKey, awsSecretKey, awsSessionToken}) => {
     <details>
       <summary>Credentials</summary>
       <Card>
-        <CardBody className="bg-light mb-3">
-          <dl>
+        <CardBody className="bg-light">
+          <dl className="mb-0" style={{display: 'grid', gridTemplateColumns: 'auto 1fr'}}>
             {
               Array.from(creds).map(([name, value]) => {
                 const id = name.toLowerCase().split(' ').join('-');
 
-                return (
-                  <div key={name}>
-                    <dt>{name}:</dt>
-                    <dd>
+                return ([
+                    <dt key={'creds-dt-'+name} className="mr-2" style={{gridColumn: 1}}>{name}:</dt>,
+                    <dd key={'creds-dd-'+name} style={{gridColumn: 2}}>
                       <InputGroupWithCopyButton
                         id={id}
                         name={`input-${id}`}
                         value={value}
                       />
                     </dd>
-                  </div>
-                );
+                ]);
               })
             }
 

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -171,8 +171,8 @@ class Refresh extends Component {
                     <p>Run these commands from a {getTerm(platform)} to use the AWS CLI:</p>
                     <PreInputGroupWithCopyButton
                       buttonClassName="bg-dark text-light"
-                      inputClassName={`bg-dark text-light ${getLang(platform)}`}
                       id="envvars"
+                      inputClassName={`bg-dark text-light ${getLang(platform)}`}
                       multiLine
                       name="input-envvars"
                       value={getEnvVars(this.props)}

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -94,6 +94,8 @@ class Refresh extends Component {
       errorMessage,
       status,
       accountId,
+      showRole,
+      roleName,
       accessKey,
       secretKey,
       sessionToken,
@@ -114,11 +116,16 @@ class Refresh extends Component {
                 <RoundedContent>
                   {errorMessage}
                   <details open>
-                    <summary>Account ID</summary>
+                    <summary>Account</summary>
                     <div className="card card-body bg-light mb-3">
-                      <pre className="card-text language-markup">
-                        <code>{accountId}</code>
-                      </pre>
+                      <dl className="mb-0 p-2 bg-dark text-light" style={{display: 'grid', gridTemplateColumns: 'auto 1fr'}}>
+                        <dt className="mr-2" style={{'gridColumn': 1}}>ID:</dt>
+                        <dd className="mb-0" style={{'gridColumn': 2}}>{accountId}</dd>
+                        {showRole && [
+                          <dt key="role-name-dt" className="mr-2" style={{gridColumn: 1}}>Role:</dt>,
+                          <dd key="role-name-dd" className="mb-0" style={{gridColumn: 2}}>{roleName}</dd>
+                        ]}
+                      </dl>
                     </div>
                   </details>
                   <Credentials

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -34,6 +34,23 @@ const LinkWithButtonMargin = styled(Link)`
 ${BUTTON_MARGIN}
 `;
 
+const AccountProps = styled.dl`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  margin: 0;
+  padding: .5rem;
+`;
+
+const AccountPropsKey = styled.dt`
+  grid-column: 1;
+  margin-right: .5rem;
+`;
+
+const AccountPropsVal = styled.dd`
+  grid-column: 2;
+  margin-bottom: 0;
+`;
+
 const getLang = (platform) => platform === 'win32' ? 'language-batch' : 'language-bash';
 
 const getTerm = (platform) => platform === 'win32' ? 'command prompt' : 'terminal';
@@ -126,58 +143,18 @@ class Refresh extends Component {
                   <details open>
                     <summary>Account</summary>
                     <div className="card card-body bg-light mb-3">
-                      <dl
-                        className="mb-0 p-2 bg-dark text-light"
-                        style={{
-                          display: 'grid',
-                          gridTemplateColumns: 'auto 1fr',
-                        }}
-                      >
+                      <AccountProps className="bg-dark text-light">
                         {this.showProfileName() && [
-                          <dt
-                            className="mr-2"
-                            key="profile-name-dt"
-                            style={{gridColumn: 1}}
-                          >
-                            Profile:
-                          </dt>,
-                          <dd
-                            className="mb-0"
-                            key="profile-name-dd"
-                            style={{gridColumn: 2}}
-                          >
-                            {profileName}
-                          </dd>,
+                          <AccountPropsKey key="profile-name-dt">Profile:</AccountPropsKey>,
+                          <AccountPropsVal key="profile-name-dd">{profileName}</AccountPropsVal>,
                         ]}
-                        <dt
-                          className="mr-2"
-                          style={{gridColumn: 1}}
-                        >
-                          ID:
-                        </dt>
-                        <dd
-                          className="mb-0"
-                          style={{gridColumn: 2}}
-                        >
-                          {accountId}
-                        </dd>
+                        <AccountPropsKey>ID:</AccountPropsKey>
+                        <AccountPropsVal>{accountId}</AccountPropsVal>
                         {showRole && [
-                          <dt
-                            className="mr-2"
-                            key="role-name-dt"
-                            style={{gridColumn: 1}}
-                          >
-                            Role:
-                          </dt>,
-                          <dd
-                            className="mb-0"
-                            key="role-name-dd"
-                            style={{gridColumn: 2}}
-                          >
-                            {roleName}
-                          </dd>,
+                          <AccountPropsKey key="role-name-dt">Role:</AccountPropsKey>,
+                          <AccountPropsVal key="role-name-dd">{roleName}</AccountPropsVal>,
                         ]}
-                      </dl>
+                      </AccountProps>
                     </div>
                   </details>
                   <Credentials

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -17,6 +17,7 @@ import {Logo} from '../components/Logo';
 import {Credentials} from './Credentials';
 import {Logout} from './Logout';
 import {RenderIfLoaded} from '../components/RenderIfLoaded';
+import {InputGroupWithCopyButton} from '../components/InputGroupWithCopyButton';
 import {
   RoundedContent,
   RoundedWrapper,
@@ -127,9 +128,13 @@ class Refresh extends Component {
                   />
                   <EnvVar>
                     <p>Run these commands from a {getTerm(platform)} to use the AWS CLI:</p>
-                    <pre className={getLang(platform)}>
-                      {getEnvVars(this.props)}
-                    </pre>
+                    <InputGroupWithCopyButton
+                      className={getLang(platform)}
+                      id="envvars"
+                      name="input-envvars"
+                      value={getEnvVars(this.props)}
+                      multiLine={true}
+                    />
                   </EnvVar>
                   <span className="ml-auto p-2">
                     <LinkWithButtonMargin

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -53,8 +53,10 @@ class Refresh extends Component {
     fetchRefresh: PropTypes.func,
     platform: PropTypes.string,
     redirect: PropTypes.bool,
+    roleName: PropTypes.string,
     secretKey: PropTypes.string,
     sessionToken: PropTypes.string,
+    showRole: PropTypes.bool,
     status: PropTypes.number,
   };
 
@@ -118,12 +120,40 @@ class Refresh extends Component {
                   <details open>
                     <summary>Account</summary>
                     <div className="card card-body bg-light mb-3">
-                      <dl className="mb-0 p-2 bg-dark text-light" style={{display: 'grid', gridTemplateColumns: 'auto 1fr'}}>
-                        <dt className="mr-2" style={{'gridColumn': 1}}>ID:</dt>
-                        <dd className="mb-0" style={{'gridColumn': 2}}>{accountId}</dd>
+                      <dl
+                        className="mb-0 p-2 bg-dark text-light"
+                        style={{
+                          display: 'grid',
+                          gridTemplateColumns: 'auto 1fr',
+                        }}
+                      >
+                        <dt
+                          className="mr-2"
+                          style={{gridColumn: 1}}
+                        >
+                          ID:
+                        </dt>
+                        <dd
+                          className="mb-0"
+                          style={{gridColumn: 2}}
+                        >
+                          {accountId}
+                        </dd>
                         {showRole && [
-                          <dt key="role-name-dt" className="mr-2" style={{gridColumn: 1}}>Role:</dt>,
-                          <dd key="role-name-dd" className="mb-0" style={{gridColumn: 2}}>{roleName}</dd>
+                          <dt
+                            className="mr-2"
+                            key="role-name-dt"
+                            style={{gridColumn: 1}}
+                          >
+                            Role:
+                          </dt>,
+                          <dd
+                            className="mb-0"
+                            key="role-name-dd"
+                            style={{gridColumn: 2}}
+                          >
+                            {roleName}
+                          </dd>,
                         ]}
                       </dl>
                     </div>
@@ -138,9 +168,9 @@ class Refresh extends Component {
                     <InputGroupWithCopyButton
                       className={getLang(platform)}
                       id="envvars"
+                      multiLine
                       name="input-envvars"
                       value={getEnvVars(this.props)}
-                      multiLine={true}
                     />
                   </EnvVar>
                   <span className="ml-auto p-2">

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -52,6 +52,7 @@ class Refresh extends Component {
     errorMessage: PropTypes.string,
     fetchRefresh: PropTypes.func,
     platform: PropTypes.string,
+    profileName: PropTypes.string,
     redirect: PropTypes.bool,
     roleName: PropTypes.string,
     secretKey: PropTypes.string,
@@ -91,6 +92,10 @@ class Refresh extends Component {
     this.props.fetchRefresh();
   };
 
+  showProfileName() {
+    return this.props.profileName !== `awsaml-${this.props.accountId}`;
+  }
+
   render() {
     const {
       errorMessage,
@@ -102,6 +107,7 @@ class Refresh extends Component {
       secretKey,
       sessionToken,
       platform,
+      profileName,
     } = this.props;
 
     if (status === 401) {
@@ -127,6 +133,22 @@ class Refresh extends Component {
                           gridTemplateColumns: 'auto 1fr',
                         }}
                       >
+                        {this.showProfileName() && [
+                          <dt
+                            className="mr-2"
+                            key="profile-name-dt"
+                            style={{gridColumn: 1}}
+                          >
+                            Profile:
+                          </dt>,
+                          <dd
+                            className="mb-0"
+                            key="profile-name-dd"
+                            style={{gridColumn: 2}}
+                          >
+                            {profileName}
+                          </dd>,
+                        ]}
                         <dt
                           className="mr-2"
                           style={{gridColumn: 1}}

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -51,6 +51,11 @@ const AccountPropsVal = styled.dd`
   margin-bottom: 0;
 `;
 
+const PreInputGroupWithCopyButton = styled(InputGroupWithCopyButton)`
+  font-family: Consolas,monospace;
+  font-size: 1rem;
+`;
+
 const getLang = (platform) => platform === 'win32' ? 'language-batch' : 'language-bash';
 
 const getTerm = (platform) => platform === 'win32' ? 'command prompt' : 'terminal';
@@ -164,8 +169,9 @@ class Refresh extends Component {
                   />
                   <EnvVar>
                     <p>Run these commands from a {getTerm(platform)} to use the AWS CLI:</p>
-                    <InputGroupWithCopyButton
-                      className={getLang(platform)}
+                    <PreInputGroupWithCopyButton
+                      buttonClassName="bg-dark text-light"
+                      inputClassName={`bg-dark text-light ${getLang(platform)}`}
                       id="envvars"
                       multiLine
                       name="input-envvars"

--- a/src/containers/select-role/Role.js
+++ b/src/containers/select-role/Role.js
@@ -1,0 +1,54 @@
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import PropTypes from 'prop-types';
+import {submitSelectRole} from '../../actions/select-role';
+import {ListGroupItem} from 'reactstrap';
+import styled from 'styled-components';
+
+
+const SelectRoleButton = styled(ListGroupItem)`
+  cursor: pointer;
+`;
+
+class RoleComponent extends Component {
+  static propTypes = {
+    displayAccountId: PropTypes.bool,
+    index: PropTypes.number,
+    name: PropTypes.string,
+    accountId: PropTypes.string,
+    roleArn: PropTypes.string,
+    principalArn: PropTypes.string,
+    submitSelectRole: PropTypes.func.isRequired,
+  };
+
+  handleClick = (event) => {
+    event.preventDefault();
+    this.props.submitSelectRole({index: this.props.index});
+  };
+
+  displayName = () => {
+    if (this.props.displayAccountId) {
+      return this.props.accountId + ":" + this.props.name;
+    } else {
+      return this.props.name;
+    }
+  };
+
+  render() {
+    return (
+      <SelectRoleButton tag="button" action onClick={this.handleClick}>
+         {this.displayName()}
+      </SelectRoleButton>
+    );
+  }
+}
+
+const mapStateToProps = ({state}) => ({
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  submitSelectRole: bindActionCreators(submitSelectRole, dispatch),
+});
+
+export const Role = connect(mapStateToProps, mapDispatchToProps)(RoleComponent);

--- a/src/containers/select-role/Role.js
+++ b/src/containers/select-role/Role.js
@@ -12,13 +12,21 @@ const SelectRoleButton = styled(ListGroupItem)`
 `;
 
 class RoleComponent extends Component {
+  displayName = () => {
+    if (this.props.displayAccountId) {
+      return `${this.props.accountId}:${this.props.name}`;
+    }
+
+    return this.props.name;
+  };
+
   static propTypes = {
+    accountId: PropTypes.string,
     displayAccountId: PropTypes.bool,
     index: PropTypes.number,
     name: PropTypes.string,
-    accountId: PropTypes.string,
-    roleArn: PropTypes.string,
     principalArn: PropTypes.string,
+    roleArn: PropTypes.string,
     submitSelectRole: PropTypes.func.isRequired,
   };
 
@@ -27,24 +35,20 @@ class RoleComponent extends Component {
     this.props.submitSelectRole({index: this.props.index});
   };
 
-  displayName = () => {
-    if (this.props.displayAccountId) {
-      return this.props.accountId + ":" + this.props.name;
-    } else {
-      return this.props.name;
-    }
-  };
-
   render() {
     return (
-      <SelectRoleButton tag="button" action onClick={this.handleClick}>
-         {this.displayName()}
+      <SelectRoleButton
+        action
+        onClick={this.handleClick}
+        tag="button"
+      >
+        {this.displayName()}
       </SelectRoleButton>
     );
   }
 }
 
-const mapStateToProps = ({state}) => ({
+const mapStateToProps = () => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/containers/select-role/Role.js
+++ b/src/containers/select-role/Role.js
@@ -48,11 +48,8 @@ class RoleComponent extends Component {
   }
 }
 
-const mapStateToProps = () => ({
-});
-
 const mapDispatchToProps = (dispatch) => ({
   submitSelectRole: bindActionCreators(submitSelectRole, dispatch),
 });
 
-export const Role = connect(mapStateToProps, mapDispatchToProps)(RoleComponent);
+export const Role = connect(null, mapDispatchToProps)(RoleComponent);

--- a/src/containers/select-role/SelectRole.js
+++ b/src/containers/select-role/SelectRole.js
@@ -1,0 +1,121 @@
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import {
+  Container,
+  Row
+} from 'reactstrap';
+import {Redirect} from 'react-router-dom';
+import PropTypes from 'prop-types';
+import {fetchSelectRole} from '../../actions/select-role';
+import {ComponentWithError} from '../components/ComponentWithError';
+import {RenderIfLoaded} from '../components/RenderIfLoaded';
+import {ListGroup} from 'reactstrap';
+import styled from 'styled-components';
+import {Role} from './Role';
+import {Logo} from '../components/Logo';
+import {
+  RoundedContent,
+  RoundedWrapper,
+} from '../../constants/styles';
+
+const SelectRoleHeader = styled.h4`
+  margin-top: 15px;
+  padding-top: 15px;
+`;
+
+class SelectRole extends Component {
+  static propTypes = {
+    roles: PropTypes.array,
+    status: PropTypes.string,
+    errorMessage: PropTypes.string,
+  };
+
+  state = {
+    loaded: false,
+  };
+
+  displayAccountId = true;
+
+  async componentDidMount() {
+    this._isMounted = true;
+
+    await this.props.fetchSelectRole();
+
+    let uniqueAccountIds = new Set(this.props.roles.map(role => {return role.accountId;}));
+    if (uniqueAccountIds.size === 1) {
+      this.displayAccountId = false;
+    }
+
+    if (this._isMounted) {
+      this.setState({
+        loaded: true,
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  render() {
+    const {
+      errorMessage,
+      status,
+      roles,
+    } = this.props;
+
+    if (status === 'selected') {
+      return <Redirect to='/refresh' />;
+    }
+
+    return (
+      <RenderIfLoaded isLoaded={this.state.loaded}>
+        {() => (
+          <Container>
+            <Row className="d-flex p-2">
+              <RoundedWrapper>
+                <Logo />
+                <RoundedContent>
+                  {errorMessage}
+
+                  <SelectRoleHeader>Select a role:</SelectRoleHeader>
+                  <ListGroup>
+                    {
+                      roles.map(role =>
+                        (
+                          <Role
+                            key={'role-item-' + role.index}
+                            displayAccountId={this.displayAccountId}
+                            index={role.index}
+                            name={role.roleName}
+                            accountId={role.accountId}
+                            roleArn={role.roleArn}
+                            principalArn={role.principalArn}
+                          />
+                        )
+                      )
+                    }
+                  </ListGroup>
+                </RoundedContent>
+              </RoundedWrapper>
+            </Row>
+          </Container>
+        )}
+      </RenderIfLoaded>
+    );
+  }
+}
+
+const mapStateToProps = ({selectRole}) => ({
+  ...selectRole.fetchFailure,
+  ...selectRole.fetchSuccess,
+  ...selectRole.submitFailure,
+  ...selectRole.submitSuccess,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  fetchSelectRole: bindActionCreators(fetchSelectRole, dispatch),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ComponentWithError(SelectRole));

--- a/src/containers/select-role/SelectRole.js
+++ b/src/containers/select-role/SelectRole.js
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {
   Container,
+  ListGroup,
   Row
 } from 'reactstrap';
 import {Redirect} from 'react-router-dom';
@@ -10,13 +11,12 @@ import PropTypes from 'prop-types';
 import {fetchSelectRole} from '../../actions/select-role';
 import {ComponentWithError} from '../components/ComponentWithError';
 import {RenderIfLoaded} from '../components/RenderIfLoaded';
-import {ListGroup} from 'reactstrap';
 import styled from 'styled-components';
 import {Role} from './Role';
 import {Logo} from '../components/Logo';
 import {
   RoundedContent,
-  RoundedWrapper,
+  RoundedWrapper
 } from '../../constants/styles';
 
 const SelectRoleHeader = styled.h4`
@@ -26,23 +26,25 @@ const SelectRoleHeader = styled.h4`
 
 class SelectRole extends Component {
   static propTypes = {
+    errorMessage: PropTypes.string,
+    fetchSelectRole: PropTypes.func,
     roles: PropTypes.array,
     status: PropTypes.string,
-    errorMessage: PropTypes.string,
   };
 
   state = {
     loaded: false,
   };
 
-  displayAccountId = true;
-
   async componentDidMount() {
     this._isMounted = true;
 
     await this.props.fetchSelectRole();
 
-    let uniqueAccountIds = new Set(this.props.roles.map(role => {return role.accountId;}));
+    let uniqueAccountIds = new Set(
+      this.props.roles.map((role) => role.accountId)
+    );
+
     if (uniqueAccountIds.size === 1) {
       this.displayAccountId = false;
     }
@@ -58,6 +60,8 @@ class SelectRole extends Component {
     this._isMounted = false;
   }
 
+  displayAccountId = true;
+
   render() {
     const {
       errorMessage,
@@ -66,7 +70,7 @@ class SelectRole extends Component {
     } = this.props;
 
     if (status === 'selected') {
-      return <Redirect to='/refresh' />;
+      return <Redirect to="/refresh" />;
     }
 
     return (
@@ -82,16 +86,16 @@ class SelectRole extends Component {
                   <SelectRoleHeader>Select a role:</SelectRoleHeader>
                   <ListGroup>
                     {
-                      roles.map(role =>
+                      roles.map((role) =>
                         (
                           <Role
-                            key={'role-item-' + role.index}
+                            accountId={role.accountId}
                             displayAccountId={this.displayAccountId}
                             index={role.index}
+                            key={`role-item-${role.index}`}
                             name={role.roleName}
-                            accountId={role.accountId}
-                            roleArn={role.roleArn}
                             principalArn={role.principalArn}
+                            roleArn={role.roleArn}
                           />
                         )
                       )

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -11,6 +11,6 @@ export default combineReducers({
   logout: logoutReducer,
   profile: profileReducer,
   refresh: refreshReducer,
-  selectRole: selectRoleReducer,
   routing: routerReducer,
+  selectRole: selectRoleReducer,
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,6 +2,7 @@ import {combineReducers} from 'redux';
 import {routerReducer} from 'react-router-redux';
 import configureReducer from './configure';
 import refreshReducer from './refresh';
+import selectRoleReducer from './select-role';
 import logoutReducer from './logout';
 import profileReducer from './profile';
 
@@ -10,5 +11,6 @@ export default combineReducers({
   logout: logoutReducer,
   profile: profileReducer,
   refresh: refreshReducer,
+  selectRole: selectRoleReducer,
   routing: routerReducer,
 });

--- a/src/reducers/select-role.js
+++ b/src/reducers/select-role.js
@@ -1,0 +1,63 @@
+import {handleActions} from 'redux-actions';
+import {
+  FETCH_SELECT_ROLE_REQUEST,
+  FETCH_SELECT_ROLE_SUCCESS,
+  FETCH_SELECT_ROLE_FAILURE,
+  SUBMIT_SELECT_ROLE_REQUEST,
+  SUBMIT_SELECT_ROLE_SUCCESS,
+  SUBMIT_SELECT_ROLE_FAILURE,
+} from '../actions/select-role';
+
+const selectRoleFetchRequest = (state, action) => ({
+  ...state,
+  fetchRequest: action,
+});
+
+const selectRoleFetchSuccess = (state, {payload}) => ({
+  ...state,
+  fetchSuccess: payload,
+});
+
+const selectRoleFetchFailure = (state, {payload}) => ({
+  ...state,
+  fetchFailure: Object.assign({}, payload, {
+    ...payload,
+    errorMessage: payload.error,
+  }),
+});
+
+const selectRoleSubmitRequest = (state, action) => ({
+  ...state,
+  submitRequest: action,
+});
+
+const selectRoleSubmitSuccess = (state, {payload}) => ({
+  ...state,
+  submitSuccess: payload,
+});
+
+const selectRoleSubmitFailure = (state, {payload}) => ({
+  ...state,
+    submitFailure: Object.assign({}, payload, {
+      ...payload,
+      errorMessage: payload.error,
+    }),
+});
+
+export const SELECT_ROLE_INITIAL_STATE = {
+  fetchFailure: {},
+  fetchRequest: {},
+  fetchSuccess: {},
+  submitFailure: {},
+  submitRequest: {},
+  submitSuccess: {},
+};
+
+export default handleActions({
+  [FETCH_SELECT_ROLE_FAILURE]: selectRoleFetchFailure,
+  [FETCH_SELECT_ROLE_REQUEST]: selectRoleFetchRequest,
+  [FETCH_SELECT_ROLE_SUCCESS]: selectRoleFetchSuccess,
+  [SUBMIT_SELECT_ROLE_FAILURE]: selectRoleSubmitFailure,
+  [SUBMIT_SELECT_ROLE_REQUEST]: selectRoleSubmitRequest,
+  [SUBMIT_SELECT_ROLE_SUCCESS]: selectRoleSubmitSuccess,
+}, SELECT_ROLE_INITIAL_STATE);

--- a/src/reducers/select-role.js
+++ b/src/reducers/select-role.js
@@ -5,7 +5,7 @@ import {
   FETCH_SELECT_ROLE_FAILURE,
   SUBMIT_SELECT_ROLE_REQUEST,
   SUBMIT_SELECT_ROLE_SUCCESS,
-  SUBMIT_SELECT_ROLE_FAILURE,
+  SUBMIT_SELECT_ROLE_FAILURE
 } from '../actions/select-role';
 
 const selectRoleFetchRequest = (state, action) => ({
@@ -38,10 +38,10 @@ const selectRoleSubmitSuccess = (state, {payload}) => ({
 
 const selectRoleSubmitFailure = (state, {payload}) => ({
   ...state,
-    submitFailure: Object.assign({}, payload, {
-      ...payload,
-      errorMessage: payload.error,
-    }),
+  submitFailure: Object.assign({}, payload, {
+    ...payload,
+    errorMessage: payload.error,
+  }),
 });
 
 export const SELECT_ROLE_INITIAL_STATE = {


### PR DESCRIPTION
This adds a role switcher when multiple roles are passed via the SAML assertion.  This is similar to how the AWS console handles multiple roles.  When a single role is passed, the behavior is unchanged.

![awsaml-role-switcher](https://user-images.githubusercontent.com/2836432/43683293-14636322-984e-11e8-988a-e9873df4dfcf.gif)

This also includes a few random fixes/improvements that I found along the way:

- A copy button for the terminal copy/pasta text
- Display credential data as a grid
- Fix the bugs and URLs when running in react developer mode

**Note to reviewers:**
I am not a react or express developer, much less a react+redux+express+electron developer.  Please keep this in mind when reviewing and feel free to suggest stylistic changes.

**Note to Okta users:**

AWS requires that multiple roles are passed as multiple values to the `https://aws.amazon.com/SAML/Attributes/Role` attribute (see [the AWS docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html)).  By default, Okta passes multiple values as a single value separated by commas.  To fix this, you must contact Okta support and ask them to enable the `SAML_SUPPORT_ARRAY_ATTRIBUTES` feature flag.  See [this post](https://devforum.okta.com/t/multivalued-attributes/179/3).

Once this feature flag is enabled, you can add specify multiple roles using an Okta expression:

```
Arrays.flatten(
  "<role_arn>,<principal_arn>",
  "<role_arn>,<principal_arn>",
  "<role_arn>,<principal_arn>"
)
```