### PR TITLE
Add basic account filter/search

### DIFF
--- a/api/routes/profile.js
+++ b/api/routes/profile.js
@@ -5,11 +5,12 @@ const router = express.Router();
 
 module.exports = () => {
   router.delete('/', (req, res) => {
-    let {profile} = url.parse(req.url, true).query;
-    let idx = parseInt(profile, 10);
+    let {profileUuid} = url.parse(req.url, true).query;
     let metadataUrls = Storage.get('metadataUrls');
 
-    metadataUrls = metadataUrls.map((metadataUrl, i) => (i !== idx) ? metadataUrl : null).filter((el) => !!el);
+    metadataUrls = metadataUrls.map((metadata) =>
+      (metadata.profileUuid !== profileUuid) ? metadata : null
+    ).filter((el) => !!el);
     Storage.set('metadataUrls', metadataUrls);
 
     res.status(200).end();

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "passport-saml": "^0.33.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
+    "uuid": "^3.3.2",
     "xmldom": "^0.1.27",
     "xpath.js": "^1.1.0"
   },

--- a/src/containers/configure/Configure.js
+++ b/src/containers/configure/Configure.js
@@ -12,7 +12,7 @@ import {
   Row
 } from 'reactstrap';
 import {Logo} from '../components/Logo';
-import {RecentLogins} from './RecentLogins';
+import RecentLogins from './RecentLogins';
 import {ConfigureMetadata} from './ConfigureMetadata';
 import {
   RoundedContent,

--- a/src/containers/configure/Login.js
+++ b/src/containers/configure/Login.js
@@ -25,7 +25,7 @@ class LoginComponent extends Component {
   static propTypes = {
     deleteProfile: PropTypes.func.isRequired,
     pretty: PropTypes.string,
-    profileId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    profileUuid: PropTypes.string,
     submitConfigure: PropTypes.func.isRequired,
     url: PropTypes.string,
   };
@@ -62,7 +62,7 @@ class LoginComponent extends Component {
   handleDelete = (event) => {
     event.preventDefault();
     const payload = {
-      profile: this.props.profileId,
+      profileUuid: this.props.profileUuid,
     };
 
     this.props.deleteProfile(payload);
@@ -101,7 +101,7 @@ class LoginComponent extends Component {
             </ProfileInputGroup>
           </summary>
           <InputGroupWithCopyButton
-            id={this.props.profileId}
+            id={this.props.profileUuid}
             name={this.props.pretty}
             value={this.props.url}
           />

--- a/src/containers/configure/RecentLogins.js
+++ b/src/containers/configure/RecentLogins.js
@@ -55,7 +55,7 @@ class RecentLogins extends Component {
     const metadataUrls = this.props.metadataUrls;
     const filterText = this.state.filterText;
 
-    if (filterText === undefined || filterText === '') {
+    if (!filterText) {
       return metadataUrls;
     }
 

--- a/src/containers/configure/RecentLogins.js
+++ b/src/containers/configure/RecentLogins.js
@@ -36,6 +36,21 @@ const SearchInput = styled(Input)`
   padding-left: 30px;
 `;
 
+const filterMetadataUrls = (metadataUrls, filterText) => {
+  if (!filterText) {
+    return metadataUrls;
+  }
+
+  const tokens = filterText.split(' ').map((token) => token.toLowerCase());
+
+  return metadataUrls.filter((metadataUrl) =>
+    tokens.every((token) =>
+      metadataUrl.name.toLowerCase().indexOf(token) !== -1
+        || metadataUrl.url.toLowerCase().indexOf(token) !== -1
+    )
+  );
+};
+
 class RecentLogins extends Component {
   static propTypes = {
     metadataUrls: PropTypes.array.isRequired,
@@ -45,32 +60,10 @@ class RecentLogins extends Component {
     filterText: '',
   };
 
-  handleFilterInputChange = ({target: {value}}) => {
-    this.setState({
-      filterText: value,
-    });
-  };
-
-  filterMetadataUrls = () => {
-    const metadataUrls = this.props.metadataUrls;
-    const filterText = this.state.filterText;
-
-    if (!filterText) {
-      return metadataUrls;
-    }
-
-    const tokens = filterText.split(' ').map((token) => token.toLowerCase());
-
-    return metadataUrls.filter((metadataUrl) =>
-      tokens.every((token) =>
-        metadataUrl.name.toLowerCase().indexOf(token) !== -1
-          || metadataUrl.url.toLowerCase().indexOf(token) !== -1
-      )
-    );
-  };
+  handleFilterInputChange = ({currentTarget: {value: filterText}}) => this.setState({filterText});
 
   render() {
-    const metadataUrls = this.filterMetadataUrls();
+    const metadataUrls = filterMetadataUrls(this.props.metadataUrls, this.state.filterText);
 
     return (
       <div

--- a/src/containers/configure/RecentLogins.js
+++ b/src/containers/configure/RecentLogins.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
@@ -37,7 +36,7 @@ const SearchInput = styled(Input)`
   padding-left: 30px;
 `;
 
-class RecentLoginsComponent extends Component {
+class RecentLogins extends Component {
   static propTypes = {
     metadataUrls: PropTypes.array.isRequired,
   }
@@ -105,10 +104,4 @@ class RecentLoginsComponent extends Component {
   }
 }
 
-const mapStateToProps = () => ({
-});
-
-const mapDispatchToProps = () => ({
-});
-
-export const RecentLogins = connect(mapStateToProps, mapDispatchToProps)(RecentLoginsComponent);
+export default RecentLogins;

--- a/src/containers/configure/RecentLogins.js
+++ b/src/containers/configure/RecentLogins.js
@@ -1,8 +1,13 @@
-import React from 'react';
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import {ListGroup} from 'reactstrap';
+import {
+  ListGroup,
+  Input
+} from 'reactstrap';
 import {Login} from './Login';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 const ScrollableListGroup = styled(ListGroup)`
   overflow-x: hidden;
@@ -15,28 +20,95 @@ const RecentLoginsHeader = styled.h4`
   padding-top: 15px;
 `;
 
-export const RecentLogins = (({metadataUrls}) =>
-  (
-    <div id="recent-logins">
-      <RecentLoginsHeader>Recent Logins</RecentLoginsHeader>
-      <ScrollableListGroup>
-        {
-          metadataUrls.map(({url, name}, i) =>
-            (
-              <Login
-                key={url}
-                pretty={name}
-                profileId={i}
-                url={url}
-              />
-            )
-          )
-        }
-      </ScrollableListGroup>
-    </div>
-  )
-);
+const SearchContainer = styled.div`
+  position: absolute;
+  right: 0;
+  top: 10px;
+  width: 250px;
+`;
 
-RecentLogins.propTypes = {
-  metadataUrls: PropTypes.array.isRequired,
-};
+const SearchIcon = styled(FontAwesomeIcon)`
+  position: absolute;
+  top: 11px;
+  left: 10px;
+`;
+
+const SearchInput = styled(Input)`
+  padding-left: 30px;
+`;
+
+class RecentLoginsComponent extends Component {
+  static propTypes = {
+    metadataUrls: PropTypes.array.isRequired,
+  }
+
+  state = {
+    filterText: '',
+  };
+
+  handleFilterInputChange = ({target: {value}}) => {
+    this.setState({
+      filterText: value,
+    });
+  };
+
+  filterMetadataUrls = () => {
+    const metadataUrls = this.props.metadataUrls;
+    const filterText = this.state.filterText;
+
+    if (filterText === undefined || filterText === '') {
+      return metadataUrls;
+    }
+
+    const tokens = filterText.split(' ').map((token) => token.toLowerCase());
+
+    return metadataUrls.filter((metadataUrl) =>
+      tokens.every((token) =>
+        metadataUrl.name.toLowerCase().indexOf(token) !== -1
+          || metadataUrl.url.toLowerCase().indexOf(token) !== -1
+      )
+    );
+  };
+
+  render() {
+    const metadataUrls = this.filterMetadataUrls();
+
+    return (
+      <div
+        className="position-relative"
+        id="recent-logins"
+      >
+        <RecentLoginsHeader>Recent Logins</RecentLoginsHeader>
+        <SearchContainer>
+          <SearchInput onChange={this.handleFilterInputChange} />
+          <SearchIcon
+            color="grey"
+            icon={['fas', 'search']}
+          />
+        </SearchContainer>
+        <ScrollableListGroup>
+          {
+            metadataUrls.map(({url, name}, i) =>
+              (
+                <Login
+                  key={url}
+                  pretty={name}
+                  profileId={i}
+                  url={url}
+                />
+              )
+            )
+          }
+        </ScrollableListGroup>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = () => ({
+});
+
+const mapDispatchToProps = () => ({
+});
+
+export const RecentLogins = connect(mapStateToProps, mapDispatchToProps)(RecentLoginsComponent);

--- a/src/containers/configure/RecentLogins.js
+++ b/src/containers/configure/RecentLogins.js
@@ -80,12 +80,12 @@ class RecentLogins extends Component {
         </SearchContainer>
         <ScrollableListGroup>
           {
-            metadataUrls.map(({url, name}, i) =>
+            metadataUrls.map(({url, name, profileUuid}) =>
               (
                 <Login
                   key={url}
                   pretty={name}
-                  profileId={i}
+                  profileUuid={profileUuid}
                   url={url}
                 />
               )

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import fontawesome from '@fortawesome/fontawesome';
 import faCopy from '@fortawesome/fontawesome-free-regular/faCopy';
 import faTrashAlt from '@fortawesome/fontawesome-free-regular/faTrashAlt';
+import faSearch from '@fortawesome/fontawesome-free-solid/faSearch';
 import faExclamationTriangle from '@fortawesome/fontawesome-free-solid/faExclamationTriangle';
 
 import App from './containers/App';
@@ -54,7 +55,7 @@ injectGlobal`
 `;
 /* eslint-enable no-unused-expressions */
 
-fontawesome.library.add(faCopy, faTrashAlt, faExclamationTriangle);
+fontawesome.library.add(faCopy, faTrashAlt, faSearch, faExclamationTriangle);
 
 const target = document.querySelector('#root');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8294,6 +8294,10 @@ uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"


### PR DESCRIPTION
This adds a very rudimentary search function for recent logins.  It's a simple case insenstive search.  It doesn't re-order results or anything fancy like that.  This should make it easier to quickly find accounts if you have given them helpful aliases.

Currently it searches both the name and url.  Searching the URL may not make sense, but it didn't hurt in my tests.

<img width="796" alt="awsaml-search" src="https://user-images.githubusercontent.com/2836432/43696583-43e0b454-9904-11e8-91c4-56d31dda8ffb.png">


GH-118