### PR TITLE
Feature: Prep v2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [2.0.1] - 2018-08-08
+### Added
+- Search for recent logins (rapid7/awsaml#120)
+- Multiple role support (rapid7/awsaml#119)
+- Copy/paste button for terminal export commands
+
+### Changed
+- Backend improvements to identify each recent login profile with a unique UUID
+
 ## [2.0.0] - 2018-07-26
 This release represents a massive overhaul to how Awsaml's internals work. There are no changes to the way users
 interact with the tool aside from some nice bells and whistles. However, internally some of the changes include:
@@ -101,7 +110,8 @@ interact with the tool aside from some nice bells and whistles. However, interna
 ### Added
 - Initial release by @onefrankguy.
 
-[Unreleased]: https://github.com/rapid7/awsaml/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/rapid7/awsaml/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/rapid7/awsaml/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/rapid7/awsaml/compare/v1.6.1...v2.0.0
 [1.6.1]: https://github.com/rapid7/awsaml/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/rapid7/awsaml/compare/v1.5.0...v1.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awsaml",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Periodically refreshes AWS access keys",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The bumps the version to 2.0.1 and adds notes to the CHANGELOG so we can cut a new release.