### PR TITLE
Disable hardware acceleration

### DIFF
--- a/electron/electron.js
+++ b/electron/electron.js
@@ -76,6 +76,8 @@ const loadTouchBar = (browserWindow) => {
 };
 
 Application.commandLine.appendSwitch('disable-http-cache');
+// No reason for Awsaml to force Macs to use dedicated gfx
+Application.disableHardwareAcceleration();
 
 Application.on('window-all-closed', () => {
   Application.quit();


### PR DESCRIPTION
There's absolutely no reason that hardware acceleration should be enabled by default and on a Mac laptop it will pin the GPU to discrete graphics mode which eats up battery life.