### PR TITLE
Name connections

### DIFF
--- a/api/routes/configure.js
+++ b/api/routes/configure.js
@@ -34,6 +34,9 @@ module.exports = (app, auth) => {
       Storage.set('metadataUrls', storedMetadataUrls);
     }
 
+    let defaultMetadataName = app.get('profileName')
+      || '';
+
     // We populate the value of the metadata url field on the following (in order of precedence):
     //   1. Use the current session's metadata url (may have been rejected).
     //   2. Use the latest validated metadata url.
@@ -55,6 +58,7 @@ module.exports = (app, auth) => {
     }
 
     res.json(Object.assign({}, ResponseObj, {
+      defaultMetadataName,
       defaultMetadataUrl,
       error: Storage.get('metadataUrlError'),
       metadataUrlValid: Storage.get('metadataUrlValid'),
@@ -113,9 +117,13 @@ module.exports = (app, auth) => {
     }
 
     app.set('metadataUrl', metadataUrl);
+    app.set('profileName', profileName);
 
     const origin = req.body.origin;
-    const metaDataResponseObj = Object.assign({}, ResponseObj, {defaultMetadataUrl: metadataUrl});
+    const metaDataResponseObj = Object.assign({}, ResponseObj, {
+      defaultMetadataName: profileName,
+      defaultMetadataUrl: metadataUrl,
+    });
 
     const xmlReq = https.get(metadataUrl, (xmlRes) => {
       let xml = '';

--- a/api/routes/configure.js
+++ b/api/routes/configure.js
@@ -48,6 +48,9 @@ module.exports = (app, auth) => {
     if (!defaultMetadataUrl) {
       if (storedMetadataUrls.length > 0 && storedMetadataUrls[0].hasOwnProperty('url')) {
         defaultMetadataUrl = storedMetadataUrls[0].url;
+        if (storedMetadataUrls[0].hasOwnProperty('name')) {
+          defaultMetadataName = storedMetadataUrls[0].name;
+        }
       }
     }
 

--- a/src/containers/components/ComponentWithError.js
+++ b/src/containers/components/ComponentWithError.js
@@ -36,6 +36,7 @@ export const ComponentWithError = (WrappedComponent) => {
           {...this.props}
           {...this.state}
           errorMessage={this.errorMessage}
+          nameGroupClass={'form-group'}
           urlGroupClass={getErrorClass(this.hasError())}
         />
       );

--- a/src/containers/configure/Configure.js
+++ b/src/containers/configure/Configure.js
@@ -30,6 +30,7 @@ const RoundedCenteredDivColumnWrapper = RoundedWrapper.extend(CenteredDivColumn)
 
 class Configure extends Component {
   static propTypes = {
+    defaultMetadataName: PropTypes.string,
     defaultMetadataUrl: PropTypes.string,
     fetchConfigure: PropTypes.func.isRequired,
     location: PropTypes.object.isRequired,
@@ -77,7 +78,10 @@ class Configure extends Component {
           <RoundedCenteredDivColumnWrapper>
             <Logo />
             <RoundedCenteredDivColumnContent>
-              <ConfigureMetadata defaultMetadataUrl={this.props.defaultMetadataUrl} />
+              <ConfigureMetadata 
+                defaultMetadataName={this.props.defaultMetadataName}
+                defaultMetadataUrl={this.props.defaultMetadataUrl}
+              />
               {!!metadataUrls.length && <RecentLogins metadataUrls={metadataUrls} />}
             </RoundedCenteredDivColumnContent>
           </RoundedCenteredDivColumnWrapper>

--- a/src/containers/configure/ConfigureMetadata.js
+++ b/src/containers/configure/ConfigureMetadata.js
@@ -83,6 +83,7 @@ class ConfigureMetadataComponent extends Component {
             onKeyDown={this.handleKeyDown}
             pattern=".+"
             type="string"
+            value={this.state.profileName}
           />
         </div>
         <Button

--- a/src/containers/configure/ConfigureMetadata.js
+++ b/src/containers/configure/ConfigureMetadata.js
@@ -8,21 +8,24 @@ import {ComponentWithError} from '../components/ComponentWithError';
 
 class ConfigureMetadataComponent extends Component {
   static propTypes = {
+    defaultMetadataName: PropTypes.string,
     defaultMetadataUrl: PropTypes.string.isRequired,
     errorMessage: PropTypes.string,
+    nameGroupClass: PropTypes.string,
     redirect: PropTypes.string,
     submitConfigure: PropTypes.func.isRequired,
     urlGroupClass: PropTypes.string,
-    nameGroupClass: PropTypes.string,
   };
 
   state = {
     metadataUrl: '',
+    profileName: '',
   };
 
   componentDidMount() {
     this.setState({
       metadataUrl: this.props.defaultMetadataUrl,
+      profileName: this.props.defaultMetadataName,
     });
   }
 
@@ -40,7 +43,7 @@ class ConfigureMetadataComponent extends Component {
 
   handleSubmit = (event) => {
     event.preventDefault();
-    const {metadataUrl,profileName} = this.state;
+    const {metadataUrl, profileName} = this.state;
     const payload = {
       metadataUrl,
       profileName,

--- a/src/containers/configure/ConfigureMetadata.js
+++ b/src/containers/configure/ConfigureMetadata.js
@@ -67,6 +67,16 @@ class ConfigureMetadataComponent extends Component {
             type="url"
             value={this.state.metadataUrl}
           />
+          <label htmlFor="name">Account Alias</label>
+          <input
+            className="form-control"
+            id="name"
+            name="name"
+            onChange={this.handleInputChange}
+            onKeyDown={this.handleKeyDown}
+            pattern=".+"
+            type="string"
+          />
         </div>
         <Button
           color="primary"

--- a/src/containers/configure/ConfigureMetadata.js
+++ b/src/containers/configure/ConfigureMetadata.js
@@ -40,10 +40,10 @@ class ConfigureMetadataComponent extends Component {
 
   handleSubmit = (event) => {
     event.preventDefault();
-    const {metadataUrl,name} = this.state;
+    const {metadataUrl,profileName} = this.state;
     const payload = {
       metadataUrl,
-      name,
+      profileName,
     };
 
     this.props.submitConfigure(payload);
@@ -72,11 +72,11 @@ class ConfigureMetadataComponent extends Component {
         </div>
         <div className={this.props.nameGroupClass}>
           <label htmlFor="metadataUrl">SAML Metadata URL</label>
-          <label htmlFor="name">Account Alias</label>
+          <label htmlFor="profileName">Account Alias</label>
           <input
             className="form-control"
-            id="name"
-            name="name"
+            id="profileName"
+            name="profileName"
             onChange={this.handleInputChange}
             onKeyDown={this.handleKeyDown}
             pattern=".+"

--- a/src/containers/configure/ConfigureMetadata.js
+++ b/src/containers/configure/ConfigureMetadata.js
@@ -13,6 +13,7 @@ class ConfigureMetadataComponent extends Component {
     redirect: PropTypes.string,
     submitConfigure: PropTypes.func.isRequired,
     urlGroupClass: PropTypes.string,
+    nameGroupClass: PropTypes.string,
   };
 
   state = {
@@ -39,9 +40,10 @@ class ConfigureMetadataComponent extends Component {
 
   handleSubmit = (event) => {
     event.preventDefault();
-    const {metadataUrl} = this.state;
+    const {metadataUrl,name} = this.state;
     const payload = {
       metadataUrl,
+      name,
     };
 
     this.props.submitConfigure(payload);
@@ -67,6 +69,9 @@ class ConfigureMetadataComponent extends Component {
             type="url"
             value={this.state.metadataUrl}
           />
+        </div>
+        <div className={this.props.nameGroupClass}>
+          <label htmlFor="metadataUrl">SAML Metadata URL</label>
           <label htmlFor="name">Account Alias</label>
           <input
             className="form-control"

--- a/src/containers/configure/ConfigureMetadata.js
+++ b/src/containers/configure/ConfigureMetadata.js
@@ -71,7 +71,6 @@ class ConfigureMetadataComponent extends Component {
           />
         </div>
         <div className={this.props.nameGroupClass}>
-          <label htmlFor="metadataUrl">SAML Metadata URL</label>
           <label htmlFor="profileName">Account Alias</label>
           <input
             className="form-control"


### PR DESCRIPTION
Allow users to name connections on first connection.

Currently to name an account connections users must login and get the connection added to the `Recent Logins` list, only then can the user edit the historically saved connection.  This PR adds an `Account Alias` optional field to the top level connection form that, if filed in, will be use to name the connection in the `Recent Logins`.