### PR TITLE
Update cask to 2.2.0

### DIFF
--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,10 +1,9 @@
 cask 'awsaml' do
-  version '2.1.0'
-  sha256 '187f13a51cb28546fc04f127827e21b5d9c8515db577a3f5f463ac91648e512f'
+  version '2.2.0'
+  sha256 'f9a0a74c3630cc6a53b5d68bb34cd545827f9541b6393046bfff88b1658de4ae'
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
-  appcast 'https://github.com/rapid7/awsaml/releases.atom',
-          checkpoint: '600ea5739ae752442c890ece55e6d4841d05f93a64ac923dda771a30672ca3b3'
+  appcast 'https://github.com/rapid7/awsaml/releases.atom'
   name 'awsaml'
   homepage 'https://github.com/rapid7/awsaml'
 


### PR DESCRIPTION
Updates cask to version 2.2.0, bringing in some important changes.

NOTE: we are removing the appcast checkpoint
SEE: https://github.com/Homebrew/homebrew-cask/issues/48051