### PR TITLE
Adding region = us-gov-west-1 when logged onto a govcloud account

### DIFF
--- a/api/aws-credentials.js
+++ b/api/aws-credentials.js
@@ -46,7 +46,8 @@ class AwsCredentials {
         config[profile].aws_access_key_id = credentials.AccessKeyId;
         config[profile].aws_secret_access_key = credentials.SecretAccessKey;
         config[profile].aws_session_token = credentials.SessionToken;
-        config[profile].region = region
+        if (region.includes("gov"))
+          config[profile].region = region
         // Some libraries e.g. boto v2.38.0, expect an "aws_security_token" entry.
         config[profile].aws_security_token = credentials.SessionToken;
         config = ini.encode(config, {whitespace: true});

--- a/api/aws-credentials.js
+++ b/api/aws-credentials.js
@@ -4,11 +4,11 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 
 class AwsCredentials {
-  save(credentials, profile, done) {
-    this.saveAsIniFile(credentials, profile, done);
+  save(credentials, profile, done, region) {
+    this.saveAsIniFile(credentials, profile, done, region);
   }
 
-  saveAsIniFile(credentials, profile, done) {
+  saveAsIniFile(credentials, profile, done, region) {
     const home = AwsCredentials.resolveHomePath();
 
     if (!home) {
@@ -46,7 +46,7 @@ class AwsCredentials {
         config[profile].aws_access_key_id = credentials.AccessKeyId;
         config[profile].aws_secret_access_key = credentials.SecretAccessKey;
         config[profile].aws_session_token = credentials.SessionToken;
-
+        config[profile].region = region
         // Some libraries e.g. boto v2.38.0, expect an "aws_security_token" entry.
         config[profile].aws_security_token = credentials.SessionToken;
         config = ini.encode(config, {whitespace: true});

--- a/api/routes/refresh.js
+++ b/api/routes/refresh.js
@@ -75,8 +75,7 @@ module.exports = (app) => {
         region = "us-gov-west-1"
       }
       else
-        region = "us-east-1"
-
+        region = ""
       credentials.save(data.Credentials, profileName, (credSaveErr) => {
         if (credSaveErr) {
           res.json(Object.assign({}, credentialResponseObj, {

--- a/api/routes/refresh.js
+++ b/api/routes/refresh.js
@@ -70,6 +70,12 @@ module.exports = (app) => {
       const profile = metadataUrls.find((metadata) => metadata.url === metadataUrl);
 
       credentialResponseObj.profileName = profile.name;
+      
+      if (session.roleArn.includes("aws-us-gov")) {
+        region = "us-gov-west-1"
+      }
+      else
+        region = "us-east-1"
 
       credentials.save(data.Credentials, profileName, (credSaveErr) => {
         if (credSaveErr) {
@@ -79,7 +85,7 @@ module.exports = (app) => {
         } else {
           res.json(credentialResponseObj);
         }
-      });
+      }, region);
     });
   });
 


### PR DESCRIPTION
## Description
Update Awsaml to add region=us-gov-west-1 in .aws/credentials when signing into a govcloud account

This is useful because the aws cli defaults region to us-east-1 which will fail when logged into a govcloud account i.e. you would need to do 'aws s3 ls --region us-gov-west-1' 

## Testing
Built a local version of awsaml, signed into multiple consumer accounts, then a govcloud account. Then I looked inside .aws/credentials checked that the region has only been set up for govcloud accounts and commercial had been left untouched

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->