### PR TITLE
add confirmation when deleting profile

### DIFF
--- a/src/containers/configure/Login.js
+++ b/src/containers/configure/Login.js
@@ -62,11 +62,13 @@ class LoginComponent extends Component {
 
   handleDelete = (event) => {
     event.preventDefault();
-    const payload = {
-      profileUuid: this.props.profileUuid,
-    };
+    const {profileName} = this.state;
 
-    this.props.deleteProfile(payload);
+    const text = `Are you sure you want to delete the profile "${profileName ? profileName : this.props.pretty}"?`;
+    if (window.confirm(text)) {
+      const payload = { profileUuid: this.props.profileUuid };
+      this.props.deleteProfile(payload);
+    }
   };
 
   render() {


### PR DESCRIPTION
This PR adds a confirmation dialog when deleting a login entry. This is in response to issue #204 by @ceastman-r7 requesting this feature be added.

The changes have been tested on macOS and Windows.