### PR TITLE
Fix refreshing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,15 @@ export PLATFORM=darwin,linux
 yarn build
 ~~~
 
+## Local Development
+
+When developing with AWSaml, the following commands can be used to run locally:
+
+~~~bash
+yarn build  # To build the react front-end
+npm run electron  # To start the application.
+~~~
+
 ## Setup on macOS with Homebrew
 A caskfile is bundled with the repository, to install Awsaml with [Homebrew][] simply run:
 

--- a/api/routes/configure.js
+++ b/api/routes/configure.js
@@ -175,6 +175,7 @@ module.exports = (app, auth) => {
           entryPoint = entryPoint.length ? entryPoint[0].value : null;
         }
         config.auth.entryPoint = entryPoint;
+        app.set('lastEntryPointLoad', new Date());
 
         if (cert && issuer && entryPoint) {
           Storage.set('previousMetadataUrl', metadataUrl);

--- a/api/routes/refresh.js
+++ b/api/routes/refresh.js
@@ -44,6 +44,7 @@ module.exports = (app) => {
         accessKey: data.Credentials.AccessKeyId,
         secretKey: data.Credentials.SecretAccessKey,
         sessionToken: data.Credentials.SessionToken,
+        expiration: data.Credentials.Expiration,
       });
 
       const profileName = `awsaml-${session.accountId}`;
@@ -69,7 +70,7 @@ module.exports = (app) => {
       const profile = metadataUrls.find((metadata) => metadata.url === metadataUrl);
 
       credentialResponseObj.profileName = profile.name;
-      
+
       credentials.save(data.Credentials, profileName, (credSaveErr) => {
         if (credSaveErr) {
           res.json(Object.assign({}, credentialResponseObj, {

--- a/api/server-config.js
+++ b/api/server-config.js
@@ -13,7 +13,7 @@ module.exports = (auth, config, secret) => {
   app.set('baseUrl', `http://${config.server.host}:${config.server.port}/`);
   app.set('configureUrlRoute', 'configure');
   app.set('refreshUrlRoute', 'refresh');
-  app.use(morgan('dev'));
+  app.use(morgan('[:date[iso]] :method :url :status :response-time ms - :res[content-length]'));
   app.use(cookieParser(secret));
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({extended: true}));

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -166,7 +166,7 @@ Application.on('ready', async () => {
     const needLoad = !lastEntryPointLoad || elapsedSinceLastLoad > (config.aws.duration / 2 * 1000);
 
     if (entryPointUrl && needLoad) {
-      console.log('Reloading...'); // eslint-disable-line no-console
+      console.log('Reloading...', entryPointUrl); // eslint-disable-line no-console
       mainWindow.loadURL(entryPointUrl);
       Server.set('lastEntryPointLoad', Date.now());
     }

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -89,6 +89,7 @@ class Refresh extends Component {
   };
 
   async componentDidMount() {
+    this.interval = setInterval(() => this.setState({ts: new Date()}), 1000)
     this._isMounted = true;
 
     await this.props.fetchRefresh();
@@ -106,6 +107,7 @@ class Refresh extends Component {
   }
 
   componentWillUnmount() {
+    clearInterval(this.interval);
     this._isMounted = false;
   }
 
@@ -116,6 +118,21 @@ class Refresh extends Component {
 
   showProfileName() {
     return this.props.profileName !== `awsaml-${this.props.accountId}`;
+  }
+
+  relativeDate(date) {
+    const deltaSeconds = (new Date(date) - new Date()) / 1000;
+    let relative = "";
+
+    const hours = Math.floor(deltaSeconds / 3600);
+    const minutes = Math.floor((deltaSeconds % 3600) / 60);
+    const seconds = Math.floor(deltaSeconds % 60);
+
+    if (hours) relative += `${hours}h`;
+    if (minutes) relative += `${minutes}m`;
+    if (seconds) relative += `${seconds}s`;
+
+    return relative;
   }
 
   render() {
@@ -130,7 +147,9 @@ class Refresh extends Component {
       sessionToken,
       platform,
       profileName,
+      expiration,
     } = this.props;
+    const localExpiration = new Date(expiration);
 
     if (status === 401) {
       return <Redirect to="/" />;
@@ -178,6 +197,8 @@ class Refresh extends Component {
                       value={getEnvVars(this.props)}
                     />
                   </EnvVar>
+                  <div><b>Expires in:</b> {this.relativeDate(expiration)}</div>
+                  <div class="mb-3"><b>Expires at:</b> {localExpiration.toString()}</div>
                   <span className="ml-auto p-2">
                     <LinkWithButtonMargin
                       className="btn btn-secondary"

--- a/src/containers/refresh/Refresh.js
+++ b/src/containers/refresh/Refresh.js
@@ -128,9 +128,15 @@ class Refresh extends Component {
     const minutes = Math.floor((deltaSeconds % 3600) / 60);
     const seconds = Math.floor(deltaSeconds % 60);
 
-    if (hours) relative += `${hours}h`;
-    if (minutes) relative += `${minutes}m`;
-    if (seconds) relative += `${seconds}s`;
+    if (hours) {
+      relative += `${hours}h`;
+    }
+    if (minutes) {
+      relative += `${minutes}m`;
+    }
+    if (seconds) {
+      relative += `${seconds}s`;
+    }
 
     return relative;
   }


### PR DESCRIPTION
The problem with using `setInterval` with a long interval in Electron is that, in the event of a computer sleep, the interval will not continue from the wall time, but rather from when the computer resumed sleep.

This is an issue with AWSAML where tokens only live for 1 hour and say you wanna grab lunch. Sometimes the tokens are expired but the refresh still hasn't fired yet.

This PR fixes that by tracking the last refresh time and polling it with a shorter `setInterval` duration.
It also adds timestamps and a timedelta so users are always aware of their token expiration status.