### PR TITLE
Update brew cask to 2.3.0

### DIFF
--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,11 +1,12 @@
-cask 'awsaml' do
-  version '2.2.2'
-  sha256 'bd314a4960ee4c996733af19cf9f77385625480b61136dd0f53fa91ede65f10e'
+cask "awsaml" do
+  version "2.3.0"
+  sha256 "08aac0225232a9330570176b19651cd6c330841daad06f5e37bae207a5368776"
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/awsaml-v#{version}-darwin-x64.zip"
-  appcast 'https://github.com/rapid7/awsaml/releases.atom'
-  name 'awsaml'
-  homepage 'https://github.com/rapid7/awsaml'
+  name "awsaml"
+  desc "Awsaml is an application for providing automatically rotated temporary AWS credentials."
+  homepage "https://github.com/rapid7/awsaml"
+  appcast "https://github.com/rapid7/awsaml/releases.atom"
 
-  app 'Awsaml.app'
+  app "Awsaml-darwin-x64/Awsaml.app"
 end


### PR DESCRIPTION
Updates brew cask for version 2.3.0 and resolves cask install issue.

Attempts to install the `awsaml` cask resulted in the following error message.
```
==> Installing Cask awsaml
==> Purging files for version 2.3.0 of Cask awsaml
Error: It seems the App source '/opt/homebrew/Caskroom/awsaml/2.3.0/Awsaml.app' is not there.
```

Following from guidance on [Cask - source is not there](https://docs.brew.sh/Common-Issues#cask---source-is-not-there) I made a minor change to the [app](https://docs.brew.sh/Cask-Cookbook#stanza-app) stanza, and was able to get it working.

```
$ cd brew/cask
$ brew install awsaml.rb
Error: Failed to load formula: awsaml.rb
awsaml: undefined method `cask' for Formulary::FormulaNamespace6b763b7c154ef9f8fca0b36bf8fb6714:Module
Did you mean?  case
Warning: Treating awsaml.rb as a cask.
==> Downloading https://github.com/rapid7/awsaml/releases/download/v2.3.0/awsaml-v2.3.0-darwin-x64.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/50682822/2683d5b
######################################################################## 100.0%
==> Installing Cask awsaml
==> Moving App 'Awsaml.app' to '/Applications/Awsaml.app'
🍺  awsaml was successfully installed!
```
