### PR TITLE
Fixed issue where ui assets wouldn't be properly packaged

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,6 @@
 name: Lint and Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:

--- a/forge.config.js
+++ b/forge.config.js
@@ -5,10 +5,9 @@ const exec = util.promisify(require('node:child_process').exec);
 const { globSync } = require('glob');
 const awsaml = require('./package.json');
 
-const includeFiles = [
+let includeFiles = [
   // we need to make sure the project root directory is included
   '',
-  ...globSync('build/**'),
   ...globSync('src/**'),
   'LICENSE.md',
   'package.json',
@@ -59,6 +58,11 @@ const config = {
       }
 
       await exec('yarn react-build');
+      // Update the files we want to include with generated build artifacts
+      includeFiles = [
+        ...includeFiles,
+        ...globSync('build/**'),
+      ];
     },
     prePackage: () => {
       // Clear the out directory if it exists


### PR DESCRIPTION
This PR fixes an issue where the `includeFiles` array will be evaluated when forge imports the config so in the event that the `build` directory is empty or doesn't exist the UI assets won't be bundled into the `app.asar`. The change adds the contents of the `build` directory at the end of the `generateAssets` hook so we know it will exist.