### PR TITLE
Make credential keys dark mode-aware.

### DIFF
--- a/src/renderer/containers/refresh/Credentials.js
+++ b/src/renderer/containers/refresh/Credentials.js
@@ -25,6 +25,14 @@ const CredPropsKey = styled.dt`
   margin-right: 1rem;
   margin-bottom: 10px;
   line-height: 2.5rem;
+
+  @media (prefers-color-scheme: light) {
+    color: #333;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: rgb(249, 249, 249);
+  }
 `;
 
 const CredPropsVal = styled.dd`


### PR DESCRIPTION
In dark mode the keys within the credentials flyout aren't dark mode-aware. In dark mode they display like this:
![image](https://github.com/rapid7/awsaml/assets/15327249/0b32d6fc-016f-4258-9023-6877a3ea2c08)
They display correctly in light mode. This PR adds conditional styling to those keys to ensure they're colored correctly.