### PR TITLE
Cask shasum mismatch for 3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,10 @@ Supported architectures are `ia32`, `x64` , `armv7l`,
 
 A caskfile is bundled with the repository, to install Awsaml with [Homebrew][] simply run:
 
-`wget https://raw.githubusercontent.com/rapid7/awsaml/master/brew/cask/awsaml.rb`
-`brew install --cask awsaml.rb`
+```
+wget https://raw.githubusercontent.com/rapid7/awsaml/master/brew/cask/awsaml.rb
+brew install --cask awsaml.rb
+```
 
 There might be an error and warning prompt but it should start succesfully downloading right after
 When download is succesfully installed, a `awsaml was successfully installed!` prompt is displayed

--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,6 +1,6 @@
 cask "awsaml" do
   version "3.1.2"
-  sha256 "b6336c92d518108469c0b2302a7da0f9c3ae7cc9916b035edf10fbaf70ae9104"
+  sha256 "1cf9093156370380b328e3250a3ff7649968aee78c8bfcb09badbcdec05e36a0"
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/Awsaml-darwin-universal-#{version}.zip"
   name "awsaml"


### PR DESCRIPTION
## Problem

It looks like [the Jenkins job](https://github.com/rapid7/awsaml/commit/ad48e4b2f9e02a3b1b8e086db151173e7c65682a) which is updating the version number in the `brew/cask/awsaml.rb` file isn't also updating the `sha256` line. 

<details>

<img width="1771" alt="Screenshot 2023-10-06 at 18 31 50" src="https://github.com/rapid7/awsaml/assets/14808878/44c7b7af-cc65-487a-ba14-aaa01effabf8">

</details>

## Band-aid

- [x] Bumping the checksum manually. I checked the shasum on 2 separate downloads, and brew successfully installed with this checksum.

<details>
<img width="1529" alt="Screenshot 2023-10-06 at 18 33 19" src="https://github.com/rapid7/awsaml/assets/14808878/fe2fecbf-800c-46e2-9f49-b4955636072f">
<img width="1211" alt="Screenshot 2023-10-06 at 18 35 57" src="https://github.com/rapid7/awsaml/assets/14808878/82d2e76b-da12-4e8a-9197-c6bbfe3d9713">

</details>

- [x] Separately, I also made a block on the doc for installing via Brew.

## Solution

I didn't open an Issue in this repo because I suspect there is a separate repo for the Jenkins job which is doing this work which will need updating. LMK if you want a ticket in the internal ticket tracking system for it.