### PR TITLE
Windows-friendly eslint linebreak config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     'import/no-extraneous-dependencies': ['error', {
       devDependencies: true,
     }],
+    'linebreak-style': ['error', process.platform === 'win32' ? 'windows' : 'unix'],
     'global-require': 0,
   },
   overrides: [


### PR DESCRIPTION
Without this, on Windows, running `yarn run react-build` errors with `Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style`