### PR TITLE
Revert version bump from draft release

### DIFF
--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,5 +1,5 @@
 cask "awsaml" do
-  version "3.2.0"
+  version "3.1.2"
   sha256 "1cf9093156370380b328e3250a3ff7649968aee78c8bfcb09badbcdec05e36a0"
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/Awsaml-darwin-universal-#{version}.zip"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awsaml",
-  "version": "3.2.0",
+  "version": "3.1.2",
   "description": "Periodically refreshes AWS access keys",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
This PR reverts the automated version bump that occurred whilst working on a release package. The draft release has been postponed.