### PR TITLE
Revert cask installer to 3.1.2

### DIFF
--- a/brew/cask/awsaml.rb
+++ b/brew/cask/awsaml.rb
@@ -1,5 +1,5 @@
 cask "awsaml" do
-  version "3.2.0"
+  version "3.1.2"
   sha256 "1cf9093156370380b328e3250a3ff7649968aee78c8bfcb09badbcdec05e36a0"
 
   url "https://github.com/rapid7/awsaml/releases/download/v#{version}/Awsaml-darwin-universal-#{version}.zip"


### PR DESCRIPTION
See title. We'll bump to 3.2.0 once we fix the build issues.