### PR TITLE
x_security_token_expires field is used for many shell completion libr…

### DIFF
--- a/src/main/api/aws-credentials.js
+++ b/src/main/api/aws-credentials.js
@@ -66,6 +66,8 @@ class AwsCredentials {
       aws_session_token: credentials.SessionToken,
       // Some libraries e.g. boto v2.38.0, expect an "aws_security_token" entry.
       aws_security_token: credentials.SessionToken,
+      // add for shell completion
+      ...(!!credentials.Expiration && { x_security_token_expires: credentials.Expiration }),
     };
 
     // Include expiration if it is available


### PR DESCRIPTION
The field x_security_token_expires is used by many shell libraries to show expiry of temporary credentials. Adding this in if it is provided.